### PR TITLE
Fix minor documentation typos

### DIFF
--- a/docs/overview/capabilities.md
+++ b/docs/overview/capabilities.md
@@ -46,7 +46,7 @@ Jo embraces the convenience of ambient authorities and make them safe:
 
 ## Capability Provision and Control
 
-The capabilities can be provied to a nested scope via the keyword `with` and
+The capabilities can be provided to a nested scope via the keyword `with` and
 controlled via `allow`, as the following example demonstrates:
 
 ```jo

--- a/docs/overview/language-tour.md
+++ b/docs/overview/language-tour.md
@@ -211,12 +211,12 @@ See [Pattern Forms](../language/patterns/pattern-forms.md).
 
 ## Class
 
-Classes can have class parameters (data class) or an explicit contructor method. Jo automatically generates a contructor function for data class with the fields defined by parameters.
+Classes can have class parameters (data class) or an explicit constructor method. Jo automatically generates a constructor function for data class with the fields defined by parameters.
 
 ```jo
 class Point(x: Int, y: Int)             // data class
 
-class Counter                            // explicit contructor
+class Counter                            // explicit constructor
   var count: Int = 0
   def Counter(v: Int): Counter =
     this.count = v

--- a/docs/security/language-design.md
+++ b/docs/security/language-design.md
@@ -49,7 +49,7 @@ More details of the capability model can be found in the paper [_A mathematical 
 
 ## Security Context
 
-Jo's langauge features enable safe representation and encapsulation of security contexts.
+Jo's language features enable safe representation and encapsulation of security contexts.
 
 **Representation** — The security context (current user) is captured in a capability object:
 


### PR DESCRIPTION
Fix minor documentation typos

## Summary

Fixes several minor typos in the documentation.

## What has changed

- Fixed a typo in the capability overview.
- Fixed two typos in the language tour.
- Fixed a typo in the security language design page.

## Testing

- [ ] Added / updated tests under `tests/pos/` or `tests/warn/`
- [ ] Ran `./ci` locally and all tests pass
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://developercertificate.org/))

Not run; markdown-only typo fixes.

## Security impact

No security impact. This is a documentation-only change.

---

## Implementation checklist (for new language features)

Not applicable; this PR does not add or change language features.