### PR TITLE
Add Nix development shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "Development shell for the Jo language toolchain";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              jdk17
+              scala-cli
+
+              nodejs_24
+              ruby
+              python3
+
+              bash
+              coreutils
+              curl
+              diffutils
+              findutils
+              git
+              gnugrep
+              gnused
+              gnumake
+              which
+            ];
+
+            shellHook = ''
+              export JAVA_HOME=${pkgs.jdk17}
+              export JO_HOME="$PWD"
+
+              echo "Jo dev shell"
+              echo "  Java:      $(java -version 2>&1 | head -n 1)"
+              echo "  Scala CLI: $(scala-cli version 2>/dev/null | head -n 1)"
+              echo "  Node:      $(node --version)"
+              echo "  Ruby:      $(ruby --version)"
+              echo "  Python:    $(python --version)"
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Summary

Adds a Nix flake with a development shell for working on Jo.

## What has changed

- Added `flake.nix` with the toolchain needed for local development.
- Added `flake.lock` to pin the `nixpkgs` revision used by the dev shell.
- The dev shell includes Java 17, Scala CLI, Node.js 24, Ruby, Python, and common command-line utilities.

## Testing

- [x] ~Added / updated tests under `tests/pos/` or `tests/warn/`~
- [x] ~Ran `./ci` locally and all tests pass~
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://developercertificate.org/))

Tested with:

```bash
nix flake check --no-build
nix develop --command bash -lc 'java -version; scala-cli version; node --version; ruby --version; python --version'
```
Did not run ./ci; this PR only adds a development shell and full CI is comparatively expensive.

Security impact
No security impact. This only adds local development environment configuration.

Implementation checklist (for new language features)
Not applicable; this PR does not add or change language features.