### PR TITLE
Harden ReadBuffer bounds checks

### DIFF
--- a/stack-lang/pickle/ReadBuffer.scala
+++ b/stack-lang/pickle/ReadBuffer.scala
@@ -43,18 +43,19 @@ class ReadBuffer(private val bytes: Array[Byte]) extends (() => Byte):
 
   def readUtf8(): String =
     val length = readNat()
+    assert(length >= 0 && length <= remaining, s"Invalid UTF-8 length: pos=$pos, length=$length, remaining=$remaining")
     val strBytes = new Array[Byte](length)
     readBytes(strBytes, length)
     new String(strBytes, java.nio.charset.StandardCharsets.UTF_8)
 
   private def readBytes(data: Array[Byte], n: Int): Unit =
-    if pos + n > bytes.length then
-      throw new Exception(s"ReadBuffer overflow: pos=$pos, n=$n, length=${bytes.length}")
+    assert(n >= 0 && n <= remaining, s"ReadBuffer overflow: pos=$pos, n=$n, length=${bytes.length}")
 
     System.arraycopy(bytes, pos, data, 0, n)
     pos += n
 
   def position: Int = pos
+  private def remaining: Int = bytes.length - pos
 
   def withPosition[T](newPos: Int)(work: => T): T =
     val savedPos = position


### PR DESCRIPTION
## Summary

Hardens `ReadBuffer` bounds checks for malformed serialized SAST input.

## What has changed

- Added an explicit remaining-byte check before allocating UTF-8 string buffers.
- Replaced an addition-based bounds check with a remaining-byte comparison to avoid integer-overflow-prone validation.
- Preserved behavior for valid serialized input.

## Testing

- [ ] Added / updated tests under `tests/pos/` or `tests/warn/`
- [ ] Ran `./ci` locally and all tests pass
- [ ] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://developercertificate.org/))

Tested with:

`scala-cli compile project.scala stack-lang/common/Base128.scala stack-lang/pickle/ReadBuffer.scala`

Also ran a malformed UTF-8 length smoke test and confirmed it fails before allocation/copy with:

`Invalid UTF-8 length: pos=1, length=5, remaining=1`

Did not run `./ci`.

## Security impact

This improves malformed SAST input hardening by rejecting invalid UTF-8 lengths before allocation and avoiding integer-overflow-prone bounds checks. It does not change behavior for valid SAST files and does not touch capability checking, FFI boundaries, or auth paths.

---

## Implementation checklist (for new language features)

Not applicable; this PR does not add or change language features.