### PR TITLE
Reject Python keywords in dynamic interop names

### DIFF
--- a/stack-lang/python/PythonRuntime.scala
+++ b/stack-lang/python/PythonRuntime.scala
@@ -7,8 +7,9 @@ import sast.Symbols.Annotation
 import scala.collection.mutable
 
 object PythonRuntime:
-  // True Python reserved keywords used for generated local names.
-  val keywords = List(
+  // Hard Python reserved keywords. These cannot be used in generated dot
+  // member syntax such as `obj.class`.
+  val hardKeywords = List(
     "False", "None", "True",
     "and", "as", "assert", "async", "await",
     "break", "class", "continue", "def", "del",
@@ -23,7 +24,12 @@ object PythonRuntime:
     "raise", "return",
     "try",
     "while", "with",
-    "yield",
+    "yield"
+  )
+
+  // Keywords/names avoided for generated local names. `match` and `case` are
+  // soft keywords: valid in `obj.match`, but best avoided as local names.
+  val keywords = hardKeywords ++ List(
     "match", "case",
     // Special names always taken in generated Python classes
     "self", "__init__"
@@ -35,13 +41,16 @@ object PythonRuntime:
   private def isPyIdentPart(c: Char): Boolean =
     c == '_' || Character.isUnicodeIdentifierPart(c)
 
-  def isValidMemberName(name: String): Boolean =
+  private def hasIdentifierShape(name: String): Boolean =
     name.nonEmpty
     && isPyIdentStart(name.head)
     && name.tail.forall(isPyIdentPart)
 
+  def isValidMemberName(name: String): Boolean =
+    hasIdentifierShape(name) && !hardKeywords.contains(name)
+
   def isValidIdentifier(name: String): Boolean =
-    isValidMemberName(name) && !keywords.contains(name)
+    hasIdentifierShape(name) && !keywords.contains(name)
 
 /** Functions to support Python platform at runtime
   *

--- a/tests/custom/python-annot-negative/targetname-keyword.jo
+++ b/tests/custom/python-annot-negative/targetname-keyword.jo
@@ -1,0 +1,5 @@
+@py.interop
+interface Foo
+  @py.targetName("class")
+  def klass(): Int
+end

--- a/tests/custom/python-annot-negative/targetname-keyword.jo.check
+++ b/tests/custom/python-annot-negative/targetname-keyword.jo.check
@@ -1,0 +1,6 @@
+---------- Error at tests/custom/python-annot-negative/targetname-keyword.jo:4:7 ---------------
+|   def klass(): Int
+|       ^^^^^
+|       @py.targetName value "class" is not a valid Python identifier
+
+1 error(s), 0 warning(s)

--- a/tests/custom/python-ffi-negative/call-keyword-name.jo
+++ b/tests/custom/python-ffi-negative/call-keyword-name.jo
@@ -1,0 +1,4 @@
+
+def main: Unit =
+  val builtins = py.module("builtins")
+  builtins.callDynamic("from")

--- a/tests/custom/python-ffi-negative/call-keyword-name.jo.check
+++ b/tests/custom/python-ffi-negative/call-keyword-name.jo.check
@@ -1,0 +1,4 @@
+[error] ---------- Error at tests/custom/python-ffi-negative/call-keyword-name.jo:4:24 ---------------
+|   builtins.callDynamic("from")
+|                        ^^^^^^
+|                        callDynamic requires a string literal name that is a valid Python identifier

--- a/tests/custom/python-ffi-negative/field-keyword-name.jo
+++ b/tests/custom/python-ffi-negative/field-keyword-name.jo
@@ -1,0 +1,4 @@
+
+def main: Unit =
+  val obj = py.module("types").SimpleNamespace()
+  obj.selectDynamic("class")

--- a/tests/custom/python-ffi-negative/field-keyword-name.jo.check
+++ b/tests/custom/python-ffi-negative/field-keyword-name.jo.check
@@ -1,0 +1,4 @@
+[error] ---------- Error at tests/custom/python-ffi-negative/field-keyword-name.jo:4:21 ---------------
+|   obj.selectDynamic("class")
+|                     ^^^^^^^
+|                     selectDynamic requires a string literal name that is a valid Python identifier

--- a/tests/custom/python-ffi-negative/setfield-keyword-name.jo
+++ b/tests/custom/python-ffi-negative/setfield-keyword-name.jo
@@ -1,0 +1,4 @@
+
+def main =
+  val obj = py.module("types").SimpleNamespace()
+  obj.updateDynamic("class", "hello")

--- a/tests/custom/python-ffi-negative/setfield-keyword-name.jo.check
+++ b/tests/custom/python-ffi-negative/setfield-keyword-name.jo.check
@@ -1,0 +1,4 @@
+[error] ---------- Error at tests/custom/python-ffi-negative/setfield-keyword-name.jo:4:21 ---------------
+|   obj.updateDynamic("class", "hello")
+|                     ^^^^^^^
+|                     updateDynamic requires a string literal name that is a valid Python identifier

--- a/tests/custom/python-ffi/app.jo
+++ b/tests/custom/python-ffi/app.jo
@@ -45,6 +45,9 @@ def main =
   os.custom_attr = "hello"
   val attr: String = os.custom_attr.asString
   println("setField/field = " + attr)
+  os.updateDynamic("match", "soft keyword")
+  val softKeywordAttr: String = os.selectDynamic("match").asString
+  println("soft keyword field = " + softKeywordAttr)
 
   // Test kwarg
   val formatter: py.Dynamic = py.module("string")

--- a/tests/custom/python-ffi/expect.check
+++ b/tests/custom/python-ffi/expect.check
@@ -7,6 +7,7 @@ try sqrt(4) = ok: 2.0
 try log(-1) = err
 dict[x] = 42
 setField/field = hello
+soft keyword field = soft keyword
 kwarg capwords = Jo-Ffi
 isInstance(42, int) = true
 isIdentical(os, alias) = true


### PR DESCRIPTION
Fix #XXX: Reject Python keywords in dynamic interop names

## Summary

Reject Python keywords when emitting dynamic Python interop member names, preventing the Python backend from generating invalid syntax such as `obj.class` or `obj.from`.

## What has changed

- Tightened Python dynamic interop name validation to reject Python keywords.
- Applied the same validation to `@py.targetName`.
- Added negative tests for keyword names in `selectDynamic`, `updateDynamic`, `callDynamic`, and `@py.targetName`.

## Testing

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Ran `./ci` locally and all tests pass~
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

Ran:

- `tests/custom/python-ffi-negative/test.sh`
- `tests/custom/python-annot-negative/test.sh`

Both passed.

## Security impact

This touches Python FFI boundary validation. It tightens accepted dynamic interop names so Python keywords are rejected at compile time instead of generating invalid Python code.

---

## Implementation checklist (for new language features)

Not applicable; this PR does not add or change language features.