### PR TITLE
Use null-prototype objects in js.obj

### DIFF
--- a/runtime/javascript/js.jo
+++ b/runtime/javascript/js.jo
@@ -350,13 +350,15 @@ def all(values: ..Any): Promise =
   global.Promise.all(array ..values).cast[Promise]
 
 //[ Create a JavaScript plain object from a Jo map literal.
+  ! The object has a null prototype so keys such as `"__proto__"` are stored
+  ! as ordinary own properties instead of changing the object's prototype.
   !
   ! ```jo
   ! val d: js.Dynamic = js.obj("x" ~ 1, "y" ~ 2)
   ! ```
 //]
 def obj(pairs: ..(String ~ Any)): Dynamic =
-  val result: Dynamic = js.init(js.global.Object)
+  val result: Dynamic = js.global.Object.create(js.null)
   for k ~ v in pairs do
     js.dynamic(result)[k] = v
   result

--- a/tests/custom/js-ffi/app.jo
+++ b/tests/custom/js-ffi/app.jo
@@ -187,6 +187,13 @@ def testObj =
   println("obj[x] = " + obj["x"].asInt)
   println("obj[y] = " + obj["y"].asString)
 
+  val proto: js.Dynamic = js.obj("polluted" ~ true)
+  val protoKeyObj: js.Dynamic = js.obj("__proto__" ~ proto)
+  val protoValue: js.Dynamic = protoKeyObj["__proto__"]
+  println("hasOwn __proto__ = " + js.hasOwn(protoKeyObj, "__proto__"))
+  println("proto key value = " + protoValue["polluted"].asBool)
+  println("inherited polluted undefined = " + protoKeyObj.polluted.isUndefined)
+
 //[ 13. js.dynamic: wrap any value back to js.Dynamic //]
 def testDynamic =
   println "--- dynamic ---"

--- a/tests/custom/js-ffi/expect.check
+++ b/tests/custom/js-ffi/expect.check
@@ -60,6 +60,9 @@ obj.x = 1
 obj.y = hello
 obj[x] = 1
 obj[y] = hello
+hasOwn __proto__ = true
+proto key value = true
+inherited polluted undefined = true
 --- dynamic ---
 value type = true
 value string = hello


### PR DESCRIPTION
Fix #XXX: Harden js.obj against prototype key mutation

## Summary

Make `js.obj` create null-prototype JavaScript objects so special keys such as `"__proto__"` are stored as ordinary own properties instead of changing the object's prototype.

## What has changed

- Changed `js.obj` to use `Object.create(null)` instead of constructing a normal `Object`.
- Added a JavaScript FFI regression test covering `"__proto__"` as an object key.
- Updated the expected JavaScript FFI test output.

## Testing

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [ ] Ran `./ci` locally and all tests pass
- [ ] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

Ran:

- `tests/custom/js-ffi/test.sh`
- `tests/custom/js-ffi-negative/test.sh`
- `tests/custom/js-annot-negative/test.sh`

All passed.

## Security impact

This touches the JavaScript FFI helper for constructing dynamic objects. It prevents `"__proto__"` keys passed to `js.obj` from mutating the created object's prototype and makes them behave like ordinary own properties.

---

## Implementation checklist (for new language features)

Not applicable; this PR does not add or change language features.