### PR TITLE
Allow multi-line expression at infix operator boundary

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,9 @@ Fix #XXX: A short description
 
 ## What has changed
 
-## Testing
+## Checklist
 
 - [ ] Added / updated tests under `tests/pos/` or `tests/warn/`
-- [ ] Ran `./ci` locally and all tests pass
 - [ ] Docs updated if the change affects user-visible behavior
 - [ ] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.10.0-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.10.0)
+  [![Release](https://img.shields.io/badge/release-v0.11.0-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.0)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,8 @@ Bundle all repository changes for the release into a single PR and merge it to
 
 - [ ] Bump the version: `stack-lang/tool/JoVersion.scala` —
       `val current: Version = Version(X, Y, Z)`
+- [ ] Update the release badge in `README.md` to `vX.Y.Z` (both the badge
+      image URL and the release tag link)
 - [ ] Update `CHANGELOG.md` with notable changes under the new version heading
 - [ ] Append the new entry to `docs/public/versions.jsonl` (the release
       download/checksum URLs follow the `vX.Y.Z` naming, so they can be added

--- a/docs/language/expressions/expression-forms.md
+++ b/docs/language/expressions/expression-forms.md
@@ -50,8 +50,8 @@ Expressions are sequences of one or more words, plus a few extended forms:
 
 See [Applications](applications.md) for colon call and dot chain syntax, [Control Flow](control-flow.md) for `if`, `match`, and `rescue`, [Lambdas](lambdas.md) for lambda syntax.
 
-::: info Multi-line open expressions
-An open expression may span several lines when it is broken at an **infix operator** boundary — either a line ends with an operator (trailing), or the next line begins with an infix operator (leading):
+::: info Multi-line open word sequence
+An open word sequence may span several lines when it is broken at an **infix operator** boundary — either a line ends with an operator (trailing), or the next line begins with an infix operator (leading):
 
 ```jo
 val total =

--- a/docs/language/expressions/expression-forms.md
+++ b/docs/language/expressions/expression-forms.md
@@ -50,6 +50,37 @@ Expressions are sequences of one or more words, plus a few extended forms:
 
 See [Applications](applications.md) for colon call and dot chain syntax, [Control Flow](control-flow.md) for `if`, `match`, and `rescue`, [Lambdas](lambdas.md) for lambda syntax.
 
+::: info Multi-line open expressions
+An open expression may span several lines when it is broken at an **infix operator** boundary — either a line ends with an operator (trailing), or the next line begins with an infix operator (leading):
+
+```jo
+val total =
+  100 +
+  200 +
+  300
+
+val eligible =
+  user.active
+  && user.verified
+  || user.isAdmin
+```
+
+A continuation line must be **aligned with, or more indented than**, the first line of the expression; a line that is *less* indented ends it. Continuation also requires an operator boundary, so consecutive statements at the same indentation stay separate:
+
+```jo
+println total
+println count          // a separate statement: no separating operator
+```
+
+The token at the break must be a genuine **infix** operator. A line that merely *begins* with a prefix operator — written with no space before its operand, such as `-x` — does not, on its own, continue the previous line. It does continue when the previous line ends with a trailing infix operator, in which case the prefix expression is its right operand:
+
+```jo
+val net =
+  gross +
+  -fee                 // operand of the trailing `+`, so the line continues
+```
+:::
+
 ## Phrases
 
 A phrase is anything that can appear in a block. Every expression is a valid phrase. Phrase-only constructs (not valid in delimited positions) are:

--- a/lib/regex/Validator.jo
+++ b/lib/regex/Validator.jo
@@ -341,15 +341,15 @@ private class Validator(source: String)
     else
       None
 
-  private def isSupportedEscape(ch: Char): Bool = (
+  private def isSupportedEscape(ch: Char): Bool =
     ch == '.' || ch == '*' || ch == '+' || ch == '?' ||
-    ch == '(' || ch == ')' || ch == '[' || ch == ']' ||
-    ch == '{' || ch == '}' || ch == '|' || ch == '\\' ||
-    ch == 'n' || ch == 'r' || ch == 't' || ch == 'f' ||
-    ch == 'b' || ch == 'B' ||
-    ch == 'd' || ch == 'D' || ch == 'w' || ch == 'W' ||
-    ch == 's' || ch == 'S'
-  )
+      ch == '(' || ch == ')' || ch == '[' || ch == ']' ||
+      ch == '{' || ch == '}' || ch == '|' || ch == '\\' ||
+      ch == 'n' || ch == 'r' || ch == 't' || ch == 'f' ||
+      ch == 'b' || ch == 'B' ||
+      ch == 'd' || ch == 'D' || ch == 'w' || ch == 'W' ||
+      ch == 's' || ch == 'S'
+
 
   private def isAlpha(ch: Char): Bool =
     ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z')

--- a/stack-lang/parsing/Parser.scala
+++ b/stack-lang/parsing/Parser.scala
@@ -1809,7 +1809,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     def shouldContinueWithLimit: Boolean =
       if !item.indent.isFirstOfLine then return true
 
-      if item.indent.isDedent(limit.get) then return false
+      if item.indent.isOutdent(limit.get) then return false
 
       val isLastOperator = buf.last match
         case Ident(name) if Naming.isOperator(name) => true

--- a/stack-lang/parsing/Parser.scala
+++ b/stack-lang/parsing/Parser.scala
@@ -97,7 +97,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
   def next(): TokenInfo = scanner.next()
   def peek(): Token = scanner.peek(0)
   def peek(i: Int): Token = scanner.peek(i)
-  def peekItem(): TokenInfo = scanner.peekItem(0)
+  def peekItem(i: Int = 0): TokenInfo = scanner.peekItem(i)
   def eat(expect: Token): TokenInfo =
     val item = peekItem()
     if item.token != expect then
@@ -1427,7 +1427,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     Allow(body, params)(allowItem.span | body.span)
 
   /** delimited expression, possibly limited by newline for inline colon args */
-  def expr(endOnNewLine: Boolean = false): Word =
+  def expr(limit: Option[Indent] = None): Word =
     val item = peekItem()
     val token = item.token
     token match
@@ -1447,7 +1447,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
       case _ =>
         word(prevWord = null) match
           case Some(w) =>
-            words(mutable.ArrayBuffer(w), endOnNewLine)
+            words(mutable.ArrayBuffer(w), limit)
 
           case None =>
             error("Expect delimited expression (words, if/else, lambda), found = " + token, item.span.toPos)
@@ -1474,7 +1474,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
             throw new SyntaxError
 
         val item = peekItem()
-        if headItem.indent.isUnindent(item.indent) then return w
+        val isDedent = headItem.indent.isUnindent(item.indent)
 
         item.token match
           case Token.EQL if allowAssign =>
@@ -1486,7 +1486,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
           case Token.COLON =>
             colonCall(w)
 
-          case Token.DOT =>
+          case Token.DOT if !isDedent =>
             dotChain(w, headItem.indent)
 
           case Token.RESCUE =>
@@ -1502,18 +1502,18 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
               RescueExpr(w, pat, handler)(w.span | handler.span)
 
           case _ =>
-            words(mutable.ArrayBuffer(w), endOnNewLine = true)
+            words(mutable.ArrayBuffer(w), limit = Some(headItem.indent))
 
   private def inlineColonArgs(colonIndent: Indent): List[CallArg] =
     def inlineColonArg(): CallArg =
       if peek().isInstanceOf[Token.Name] && peek(1) == Token.EQL then
         val id = name()
         eat(Token.EQL)
-        val rhs = expr(endOnNewLine = true)
+        val rhs = expr(limit = Some(colonIndent))
         NamedArg(id, rhs)(id.span | rhs.span)
 
       else
-        expr(endOnNewLine = true)
+        expr(limit = Some(colonIndent))
 
     val acc = mutable.ArrayBuffer.empty[CallArg]
 
@@ -1783,12 +1783,12 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
 
   def words(keyword: TokenInfo): Word =
     word(prevWord = null) match
-      case Some(w) => words(mutable.ArrayBuffer(w), endOnNewLine = false)
+      case Some(w) => words(mutable.ArrayBuffer(w), limit = None)
       case None =>
         error("Expect words after " + keyword.token + ", found none", keyword.span.toPos)
         throw new SyntaxError
 
-  def words(buf: mutable.ArrayBuffer[Word], endOnNewLine: Boolean): Word =
+  def words(buf: mutable.ArrayBuffer[Word], limit: Option[Indent]): Word =
     assert(buf.nonEmpty, "empty buf")
 
     def finish(): Word =
@@ -1805,12 +1805,38 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
             Expr(buf.toList)(span)
 
     val item = peekItem()
-    if endOnNewLine && item.indent.isFirstOfLine || item.token == Token.EOF then
+
+    def shouldContinueWithLimit: Boolean =
+      if !item.indent.isFirstOfLine then return true
+
+      if limit.get.isUnindent(item.indent) then return false
+
+      val isLastOperator = buf.last match
+        case Ident(name) if Naming.isOperator(name) => true
+        case _ => false
+
+      val isCurrentInfix = item.token match
+        case _: Token.Operator =>
+          // check whether current is infix instead of prefix
+          //
+          // prefix operator must be followed immediately by the operand
+          val item2 = peekItem(1)
+          !item2.span.followsImmediate(item.span)
+
+        case _ => false
+
+      if isLastOperator then !isCurrentInfix else isCurrentInfix
+
+    val shouldStop =
+        limit.nonEmpty && !shouldContinueWithLimit
+        || item.token == Token.EOF
+
+    if shouldStop then
       finish()
 
     else
       word(prevWord = buf.last) match
-        case Some(w) => words(buf += w, endOnNewLine)
+        case Some(w) => words(buf += w, limit)
         case None => finish()
 
   def phrase(): Word =

--- a/stack-lang/parsing/Parser.scala
+++ b/stack-lang/parsing/Parser.scala
@@ -572,7 +572,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     val id = name()
     val defs = repeated:
       val item = peekItem()
-      if item.isDedent(secToken) then None
+      if item.indent.isDedent(secToken.indent) then None
       else Some(parseTopLevelDef())
 
     eatEndOpt(secToken.indent)

--- a/stack-lang/parsing/Parser.scala
+++ b/stack-lang/parsing/Parser.scala
@@ -318,8 +318,8 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
   def skipIndented(limitIndent: Indent) =
     var item = peekItem()
     while
-      (!limitIndent.isUnindent(item.indent) || item.token == Token.END
-      && !limitIndent.isOutdent(item.indent))
+      (!item.indent.isDedent(limitIndent) ||
+       item.token == Token.END && !item.indent.isOutdent(limitIndent))
       && item.token != Token.EOF
     do
       next()
@@ -572,7 +572,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     val id = name()
     val defs = repeated:
       val item = peekItem()
-      if secToken.isUnindent(item) then None
+      if item.isDedent(secToken) then None
       else Some(parseTopLevelDef())
 
     eatEndOpt(secToken.indent)
@@ -762,7 +762,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
 
     eat(Token.EQL)
     val item = peekItem()
-    if pat.indent.isUnindent(item.indent) then
+    if item.indent.isDedent(pat.indent) then
        error("Expect cases, found nothing before the unindentation", item.span.toPos)
        throw new SyntaxError
 
@@ -776,7 +776,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
         repeated:
           if peek() == Token.CASE then
             val caseToken = next()
-            val pat = pattern(indent => caseToken.indent.isIndentOrSameLine(indent))
+            val pat = pattern(indent => indent.isIndentOrSameLine(caseToken.indent))
             val caseDef = Case(pat, Block(Nil)(pat.span))(caseToken.span | pat.span)
 
             if count > 0 then checkAlign(item, caseToken)
@@ -864,7 +864,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     var continue = true
     while continue do
       val item = peekItem()
-      if item.token == Token.EOF || klass.indent.isUnindent(item.indent) then
+      if item.token == Token.EOF || item.indent.isDedent(klass.indent) then
         continue = false
 
       else if item.token == Token.VIEW then
@@ -932,7 +932,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
 
     val members: List[FunDef] = repeated:
       val item = peekItem()
-      if interface.indent.isUnindent(item.indent) then
+      if item.indent.isDedent(interface.indent) then
         None
       else if item.token == Token.AT || item.token == Token.DEF || item.token == Token.PRIVATE || item.token == Token.DEFER then
         // Get doc comment from the first token before modifiers
@@ -967,7 +967,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     // Parse methods (same as interface, but bodies are required)
     val members: List[FunDef] = repeated:
       val item = peekItem()
-      if extToken.indent.isUnindent(item.indent) then
+      if item.indent.isDedent(extToken.indent) then
         None
       else if item.token == Token.AT || item.token == Token.DEF || item.token == Token.PRIVATE || item.token == Token.DEFER then
         val doc = processComments(peekItem().precedingComments)
@@ -1008,7 +1008,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     var continue = true
     while continue do
       val item = peekItem()
-      if item.token == Token.EOF || obj.indent.isUnindent(item.indent) then
+      if item.token == Token.EOF || item.indent.isDedent(obj.indent) then
         continue = false
 
       else if item.token == Token.VIEW then
@@ -1130,7 +1130,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     // Parse optional methods (same pattern as extensionDef)
     val funs: List[FunDef] = repeated:
       val item = peekItem()
-      if union.indent.isUnindent(item.indent) then
+      if item.indent.isDedent(union.indent) then
         None
       else if item.token == Token.AT || item.token == Token.DEF || item.token == Token.PRIVATE || item.token == Token.DEFER then
         val doc = processComments(peekItem().precedingComments)
@@ -1362,7 +1362,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
         error("Expected a phrase after " + lastItem.token, lastItem.span.toPos)
         throw new SyntaxError
 
-    else if limitIndent.isUnindent(item.indent) then
+    else if item.indent.isDedent(limitIndent) then
       error("Code expected after " + lastItem.token + ", but nothing found", lastItem.span.toPos)
       Block(phrases = Nil)(lastItem.span.endPoint)
 
@@ -1379,7 +1379,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
         Block(phrases.toList)(span)
 
     val item = peekItem()
-    if limitIndent.isUnindent(item.indent) || item.token == Token.EOF then
+    if item.indent.isDedent(limitIndent) || item.token == Token.EOF then
       finalResult()
 
     else
@@ -1474,7 +1474,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
             throw new SyntaxError
 
         val item = peekItem()
-        val isDedent = headItem.indent.isUnindent(item.indent)
+        val isDedent = item.indent.isDedent(headItem.indent)
 
         item.token match
           case Token.EQL if allowAssign =>
@@ -1547,7 +1547,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     while continue do
       val item = peekItem()
 
-      if colonIndent.isUnindent(item.indent) || item.token == Token.EOF then
+      if item.indent.isDedent(colonIndent) || item.token == Token.EOF then
         continue = false
 
       else
@@ -1573,7 +1573,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     if colonIndent.isSameLine(item.indent) then
       inlineColonArgs(colonIndent)
 
-    else if colonIndent.isIndent(item.indent) then
+    else if item.indent.isIndent(colonIndent) then
       indentedColonArgs(colonIndent)
 
     else
@@ -1775,7 +1775,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
         chain = Apply(chain, args)(chain.span | args.last.span)
 
       val item = peekItem()
-      continue = item.token == Token.DOT && !limitIndent.isUnindent(item.indent)
+      continue = item.token == Token.DOT && !item.indent.isDedent(limitIndent)
     end while
 
     chain
@@ -1809,7 +1809,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     def shouldContinueWithLimit: Boolean =
       if !item.indent.isFirstOfLine then return true
 
-      if limit.get.isUnindent(item.indent) then return false
+      if item.indent.isDedent(limit.get) then return false
 
       val isLastOperator = buf.last match
         case Ident(name) if Naming.isOperator(name) => true
@@ -1895,7 +1895,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     val nextItem = peekItem()
 
     val value =
-      if retItem.indent.isUnindent(nextItem.indent) then None
+      if nextItem.indent.isDedent(retItem.indent) then None
       else Some(block(retItem.indent, retItem))
 
     Return(value)(retItem.span | value.map(_.span).getOrElse(retItem.span))
@@ -2151,7 +2151,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     val nextItem = peekItem()
     val elsep =
       // outdent else belongs to outer if/else
-      if nextItem.token == Token.ELSE && !ifItem.indent.isOutdent(nextItem.indent) then
+      if nextItem.token == Token.ELSE && !nextItem.indent.isOutdent(ifItem.indent) then
         val elseItem = eat(Token.ELSE)
         // if cond then
         // else if cond then
@@ -2306,7 +2306,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
 
   def cases(acc: mutable.ArrayBuffer[(Case, TokenInfo)], limitIndent: Indent): List[Case] =
     val item = peekItem()
-    if item.token == Token.CASE && !limitIndent.isOutdent(item.indent) then
+    if item.token == Token.CASE && !item.indent.isOutdent(limitIndent) then
       val caseItem = eat(Token.CASE)
 
       if acc.nonEmpty then

--- a/stack-lang/parsing/Tokens.scala
+++ b/stack-lang/parsing/Tokens.scala
@@ -41,9 +41,9 @@ object Tokens:
     indent: Indent,
     precedingComments: List[RawComment]
   ):
-    /** Whether the other indentation is a unindentation to the current one */
-    def isUnindent(that: TokenInfo): Boolean =
-      that.token == Token.EOF || this.indent.isUnindent(that.indent)
+    /** Whether this token is a dedent relative to the reference. */
+    def isDedent(ref: TokenInfo): Boolean =
+      this.token == Token.EOF || this.indent.isDedent(ref.indent)
 
   /** Support for indentation syntax
     *
@@ -74,30 +74,33 @@ object Tokens:
 
     def isFirstOfLine: Boolean = lineIndent == tokenOffset
 
-    /** Whether the other indentation is an unindentation to the current one
+    /** Whether this indentation is a dedent relative to the reference.
       *
-      * TODO: rename to dedent or <=
+      * A dedent begins a line whose indentation is less than or equal (`<=`)
+      * to the reference line's indentation.
       */
-    def isUnindent(other: Indent): Boolean =
-      other.isFirstOfLine && other.tokenOffset <= this.lineIndent
+    def isDedent(ref: Indent): Boolean =
+      this.isFirstOfLine && this.tokenOffset <= ref.lineIndent
 
-    /** Whether the other indentation is a out-indentation to the current one
+    /** Whether this indentation is an outdent relative to the reference.
       *
-      * An outdent is strictly smaller (<), while unindent is <=.
+      * An outdent is strictly smaller (`<`), while a dedent is `<=`.
       *
-      * Outdent is usually in checking if/else where "else" is an unindent but
-      * not outdent.
+      * Outdent is used when checking if/else where an `else` aligned under its
+      * `if` is a dedent but not an outdent.
       */
-    def isOutdent(other: Indent): Boolean =
-      other.isFirstOfLine && other.tokenOffset < this.lineIndent
+    def isOutdent(ref: Indent): Boolean =
+      this.isFirstOfLine && this.tokenOffset < ref.lineIndent
 
-    /** Whether the other is an indentation to the current one */
-    def isIndent(other: Indent): Boolean =
-      other.isFirstOfLine && other.tokenOffset > this.lineIndent
+    /** Whether this indentation is an indent relative to the reference. */
+    def isIndent(ref: Indent): Boolean =
+      this.isFirstOfLine && this.tokenOffset > ref.lineIndent
 
-    /** Whether the other is an indentation to the current one or both on the same line? */
-    def isIndentOrSameLine(other: Indent): Boolean =
-      isSameLine(other) || isIndent(other)
+    /** Whether this indentation is an indent relative to the reference, or both
+      * are on the same line.
+      */
+    def isIndentOrSameLine(ref: Indent): Boolean =
+      isSameLine(ref) || isIndent(ref)
 
     /** Either of the following is true:
       * - `this` is first of line and has the same offset as line indentation of `this`

--- a/stack-lang/parsing/Tokens.scala
+++ b/stack-lang/parsing/Tokens.scala
@@ -40,10 +40,7 @@ object Tokens:
     span: Span,
     indent: Indent,
     precedingComments: List[RawComment]
-  ):
-    /** Whether this token is a dedent relative to the reference. */
-    def isDedent(ref: TokenInfo): Boolean =
-      this.token == Token.EOF || this.indent.isDedent(ref.indent)
+  )
 
   /** Support for indentation syntax
     *

--- a/tests/pos/line-continue-aligned.jo
+++ b/tests/pos/line-continue-aligned.jo
@@ -1,0 +1,30 @@
+// Indented infix operator line continuation, aligned variant.
+//
+// A continuation line may sit at the *same* indentation as the expression head
+// (not only deeper). Only a strictly-dedented line ends the expression, so an
+// operator-aligned style familiar from other languages is accepted.
+
+def main =
+  // trailing operators aligned with the head
+  val total =
+    100 +
+    200 +
+    300
+  println total              // 600
+
+  // leading operators aligned with the head
+  val flag =
+    1 > 0
+    && 2 > 0
+    || 3 < 0
+  println flag               // true
+
+  // aligned continuation under an inline colon head
+  println:
+    "a"
+    + "b"
+    + "c"                    // abc
+
+  // a non-operator line at the same indentation stays a separate statement
+  println "one"
+  println "two"

--- a/tests/pos/line-continue-aligned.jo.check
+++ b/tests/pos/line-continue-aligned.jo.check
@@ -1,0 +1,5 @@
+600
+true
+abc
+one
+two

--- a/tests/pos/line-continue.jo
+++ b/tests/pos/line-continue.jo
@@ -1,0 +1,40 @@
+// Indented infix operator line continuation.
+//
+// A words-expression continues onto a more-indented next line when the break
+// happens at an infix-operator boundary: either the previous line ends with an
+// operator (trailing), or the next line starts with an infix operator (leading).
+
+def main =
+  // trailing operator, inline colon head on the first line
+  println: 3 + 4
+    + 4                       // 11
+
+  // leading operators under an indented colon block
+  println:
+    "hello, this is a very long message"
+       + " some more content"
+       + " more content"      // concatenated string
+
+  // trailing operator, with a prefix operand on the continuation line
+  println:
+    3 + 4 +
+      -4 + 9                  // 12
+
+  // leading boolean operators chained across lines
+  println:
+    5 > 4
+      || 6 > 9
+      || 10 > 3               // true
+
+  // mixed leading and trailing in a single expression
+  println:
+    1 > 0
+      && 2 > 0 ||
+      3 > 0                   // true
+
+  // continuation works for a plain (non-colon) words expression too
+  val sum =
+    10 +
+      20 +
+      30
+  println sum                 // 60

--- a/tests/pos/line-continue.jo.check
+++ b/tests/pos/line-continue.jo.check
@@ -1,0 +1,6 @@
+11
+hello, this is a very long message some more content more content
+12
+true
+true
+60

--- a/tests/warn/expression-binary-op.jo.check
+++ b/tests/warn/expression-binary-op.jo.check
@@ -1,11 +1,11 @@
----------- Error at tests/warn/expression-binary-op.jo:14:3 ---------------
+---------- Error at tests/warn/expression-binary-op.jo:14:5 ---------------
 |   | * 6
-|   ^
-|   A value expected here for precedence expression
+|     ^
+|     A value expected here for precedence expression
 
----------- Error at tests/warn/expression-binary-op.jo:19:3 ---------------
-|   * 6
-|   ^
-|   Function * expects 1 pre arguments, found = 0
+---------- Error at tests/warn/expression-binary-op.jo:14:7 ---------------
+|   | * 6
+|       ^
+|       An infix operator expected here for precedence expression
 
 2 error(s), 0 warning(s)

--- a/tests/warn/line-continue-misaligned.jo
+++ b/tests/warn/line-continue-misaligned.jo
@@ -1,0 +1,14 @@
+// A more-indented continuation line only joins the previous expression when it
+// is an infix-operator boundary. A prefix operator (no space before its
+// operand) is NOT a continuation, so `-a` here starts a new, misaligned line
+// and the indentation checker reports it.
+//
+// Note the difference from `- a` (with a space), which would be parsed as an
+// infix continuation `a + 1 - a`.
+
+def main =
+  val a = 3
+  val x =
+    a + 1
+      -a
+  println x

--- a/tests/warn/line-continue-misaligned.jo.check
+++ b/tests/warn/line-continue-misaligned.jo.check
@@ -1,0 +1,6 @@
+---------- Warning at tests/warn/line-continue-misaligned.jo:13:7 ---------------
+|       -a
+|       ^
+|       Operator(-) is not aligned with Name(a), expect offset = 4, found = 6
+
+0 error(s), 1 warning(s)

--- a/tests/warn/vararg.jo
+++ b/tests/warn/vararg.jo
@@ -18,7 +18,7 @@ def main =
 
   mix 6 List 8 pass
 
-  .. l
+  ..l
 
   println (.. List("hello"))
 

--- a/tests/warn/vararg.jo.check
+++ b/tests/warn/vararg.jo.check
@@ -39,12 +39,12 @@
 |   Found extra value, an expression should produce a single value
 
 ---------- Error at tests/warn/vararg.jo:21:3 ---------------
-|   .. l
+|   ..l
 |   ^^
 |   Undefined term name ..
 
 ---------- Error at tests/warn/vararg.jo:21:3 ---------------
-|   .. l
+|   ..l
 |   ^^
 |   Expect a function, found = ..: Error
 


### PR DESCRIPTION
Allow multi-line expression at infix operator boundary

Note: _Only open expressions are affected. Closed expressions are not affected, there is no question where they end._

## Context

Semicolon omission in statement syntax leads to the problem of when an expression ends.
Languages like Go and JavaScript use heuristics to automatically insert `;` at line ends.
When things are not clear, users may add `;` explicitly.

Languages like Swift and Scala use heuristics to tell whether or not to continue a multi-line expression.

Jo's rule is closer to Swift: multi-line expressions only continue at infix operator boundaries. An operator is taken as infix if there is space to its lhs and no space to rhs. 

## What has changed

Previously, the following code is invalid:

```scala
val a = 
  "hello, " + name + ". Message received: " +
  message
```

The programmer has to use parentheses to wrap the expression as in Python.

With the current change, the code above is accepted. One condition:

- The two lines must be separated by an infix operator

## Alternative 1

The separating infix operator rule allows the following code:

```scala
gcd:
  a + b +
  3
  5
```

Arguably, no one will write the code above. They can indent `3` to make things clear:

```scala
gcd:
  a + b +
    3
  5
```

We could add the requirement that *the continued line must be indented*. However, the price to pay is that the following code patterns become invalid:

```scala
a > 3
|| b == 10
|| c > 20
```

Users have to write

```scala
a > 3
  || b == 10
  || c > 20
```

We reject the design on the following two considerations.

First, the purpose of the PR is to reduce frictions for LLMs and new comers from other languages. The restriction goes against the goal.

Second, while a syntactic restriction can be justified by it rejecting unreadable code, it is a much weaker argument than rejecting error-prone code.

## Alternative 2

Do nothing. The two common use cases for multi-line expressions are

- string concatenation
- complex Boolean expressions

Arithmetic expressions spanning multiple lines is less common and it's debatable whether it's a good style or not.

For both the two cases above, the existing colon syntax can better handle them:

```scala
def join(args: ..StringLike): String = ...

join:
  "hell, " + name + ". New message:"
  message

def or(conds: ..Bool): Bool = ...

or:
  a > 3
  b == 10
  c > 20
```

The counter-argument is friendliness for LLMs and users from other languages.


## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

No
