### PR TITLE
Restrict shape expression to terms and patterns

### DIFF
--- a/docs/language/syntax/expression-syntax.md
+++ b/docs/language/syntax/expression-syntax.md
@@ -21,11 +21,12 @@ Jo classifies expressions into three categories and applies distinct parsing str
 
 | Expression Context | Precedence | Operator | Shape |
 |-------------------|------------|----------|-------|
-| Expressions       | ✓          | ✓        | ✓     |
+| term expressions  | ✓          | ✓        | ✓     |
 | Pattern expressions | ✗        | ✓        | ✓     |
-| Type expressions  | ✗          | ✓        | ✓     |
+| Type expressions  | ✗          | ✓        | ✗     |
 
-**Precedence parsing applies to expressions only, not to pattern or type expressions.**
+- Precedence parsing applies to terms only, not to patterns or types.
+- Shape parsing applies to terms and patterns, not to types.
 
 ## Precedence Expressions
 

--- a/docs/overview/language-tour.md
+++ b/docs/overview/language-tour.md
@@ -216,16 +216,17 @@ Classes can have class parameters (data class) or an explicit constructor method
 ```jo
 class Point(x: Int, y: Int)             // data class
 
-class Counter                            // explicit constructor
+class Counter
   var count: Int = 0
-  def Counter(v: Int): Counter =
+
+  def Counter(v: Int): Counter =        // explicit constructor
     this.count = v
-    this
+
   def increment(): Unit = count = count + 1
   def value: Int = count
 end
 
-val p = new Point(3, 4)
+val p = Point(3, 4)
 val c = new Counter
 c.increment()
 println c.value                          // 1
@@ -249,7 +250,7 @@ end
 
 def print(d: Describable): Unit = println d.describe()
 
-print (new Point(3, 4))                  // (3, 4)
+print Point(3, 4)                  // (3, 4)
 ```
 
 A `view` can also delegate to a field — all interface methods are forwarded automatically:
@@ -270,15 +271,15 @@ See [Interface Definitions](../language/definitions/interface-definitions.md).
 param indent: Int = 0
 
 def line(text: String): Unit =
-  println " " * indent + text
+  println: " " * indent + text
 
-def section(title: String, items: List[String]): Unit =
+def list(title: String, items: List[String]): Unit =
   line title
   with indent = indent + 2 in
     for item in items do line item
 
 def main =
-  section("Colors", ["red", "green", "blue"])
+  list("Colors", ["red", "green", "blue"])
 ```
 
 Output:

--- a/stack-lang/typing/ExprTyper.scala
+++ b/stack-lang/typing/ExprTyper.scala
@@ -8,7 +8,6 @@ import ast.Naming
 
 import sast.*
 import sast.Trees.*
-import sast.Denotations.*
 
 import Inference.TargetType
 
@@ -141,70 +140,15 @@ class ExprTyper(namer: Namer):
       (using defn: Definitions, sc: Scope, rp: Reporter, so: Source, checks: Checks)
   : TypeTree =
 
-    val isOperatorExpr = tpt.types.exists:
-      case Ast.Ident(name) if Naming.isOperator(name) => true
-      case _ => false
+    val handler = new ExprTyper.OperatorHandler[Ast.TypeTree]:
+      def infix(lhs: Ast.TypeTree, binder: Ast.Ident, rhs: Ast.TypeTree): Ast.TypeTree =
+        Ast.AppliedType(binder, lhs :: rhs :: Nil)(lhs.span | rhs.span)
 
-    if isOperatorExpr then
-      val handler = new ExprTyper.OperatorHandler[Ast.TypeTree]:
-        def infix(lhs: Ast.TypeTree, binder: Ast.Ident, rhs: Ast.TypeTree): Ast.TypeTree =
-          Ast.AppliedType(binder, lhs :: rhs :: Nil)(lhs.span | rhs.span)
+      def error(span: Span): Ast.TypeTree = Ast.Ident("Bottom")(span)
 
-        def error(span: Span): Ast.TypeTree = Ast.Ident("Bottom")(span)
-
-      val words = mutable.ListBuffer.from(tpt.types)
-      val word = parseOperatorExpr(words, handler)
-      namer.transformValueType(word, allowPackType = allowPackType)
-
-    else
-      transformShapeExprType(tpt, allowPackType)
-
-  def transformShapeExprType(tpt: Ast.ExprType, allowPackType: Boolean)
-      (using defn: Definitions, sc: Scope, rp: Reporter, so: Source, checks: Checks)
-  : TypeTree =
-
-    val lambdaTypeHandler = new ShapeHandler[Ast.TypeTree, Ast.TypeTree]:
-      var count = 0
-      def bundle(preArgs: List[Ast.TypeTree], binder: Ast.TypeTree, postArgs: List[Ast.TypeTree]): Ast.TypeTree =
-        val startSpan = if preArgs.isEmpty then binder.span else preArgs.head.span
-        val endSpan = if postArgs.isEmpty then binder.span else postArgs.last.span
-        Ast.AppliedType(binder, preArgs ++ postArgs)(startSpan | endSpan)
-
-      def resolveShape(tpt: Ast.TypeTree): Option[Shape[Ast.TypeTree]] =
-        count += 1
-        tpt match
-          case Ast.Ident(name) if Naming.isOperator(name) =>
-            val typed =
-              tpt.getKeyOrUpdate(Namer.TypedTypeTree):
-                namer.transformType(tpt, allowPackType = allowPackType && count <= 1)
-
-            typed.tpe.typeSymbolOpt.flatMap: tsym =>
-              tsym.info match
-                case cinfo: ClassInfo if cinfo.tparams.nonEmpty =>
-                  val shape = Shape[Ast.TypeTree](tpt, preParams = 0, postParams = cinfo.tparams.size)
-                  Some(shape)
-
-                case toi: TypeOperatorInfo =>
-                  val shape = Shape[Ast.TypeTree](tpt, toi.preParamCount, toi.postParamCount)
-                  Some(shape)
-
-                case _ =>
-                  None
-
-          case _ =>
-            None
-
-    val types: mutable.ListBuffer[Ast.TypeTree] = mutable.ListBuffer.from(tpt.types)
-    val typeTrees = parseShapeExpr(types, lambdaTypeHandler)
-
-    assert(types.isEmpty, types)
-    if typeTrees.size > 1 then
-      val rest = typeTrees.init
-      val span = rest.head.span | rest.last.span
-      Reporter.error("Found extra type, a type expression should produce a single type", span.toPos)
-
-    namer.transformValueType(typeTrees.last, allowPackType = allowPackType)
-  end transformShapeExprType
+    val words = mutable.ListBuffer.from(tpt.types)
+    val word = parseOperatorExpr(words, handler)
+    namer.transformValueType(word, allowPackType = allowPackType)
 
 
   /** Form AST from the words based on shape but not on precedence */

--- a/tests/warn/type-shape.jo
+++ b/tests/warn/type-shape.jo
@@ -1,0 +1,3 @@
+type IntOption = Option Int
+
+type Foo = Result Int String

--- a/tests/warn/type-shape.jo.check
+++ b/tests/warn/type-shape.jo.check
@@ -1,0 +1,26 @@
+---------- Error at tests/warn/type-shape.jo:1:25 ---------------
+| type IntOption = Option Int
+|                         ^^^
+|                         An infix operator expected here for an operator expression
+
+---------- Error at tests/warn/type-shape.jo:1:18 ---------------
+| type IntOption = Option Int
+|                  ^^^^^^
+|                  Expect value type, but found a type of kind (*) => *
+
+---------- Error at tests/warn/type-shape.jo:3:19 ---------------
+| type Foo = Result Int String
+|                   ^^^
+|                   An infix operator expected here for an operator expression
+
+---------- Error at tests/warn/type-shape.jo:3:23 ---------------
+| type Foo = Result Int String
+|                       ^^^^^^
+|                       An infix operator expected here for an operator expression
+
+---------- Error at tests/warn/type-shape.jo:3:12 ---------------
+| type Foo = Result Int String
+|            ^^^^^^
+|            Expect value type, but found a type of kind (*, *) => *
+
+5 error(s), 0 warning(s)


### PR DESCRIPTION
Restrict shape expression to terms and patterns

## Rationale

Shape expression for types are not readable and they are not supported in any other languages. Therefore, it is better to remove the support.

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

No