### PR TITLE
Fix jo self-version upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.2] - 2026-06-27
+
+### Fixed
+
+- `jo versions install` wrote a launcher pointing at the wrong location for the
+  bundled compiler jar, so a version installed this way failed to run. The
+  installer now uses the launcher shipped in the release archive. ([#39])
+
+[#39]: https://github.com/typescope/jo/pull/39
+
 ## [0.11.1] - 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.11.1-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.1)
+  [![Release](https://img.shields.io/badge/release-v0.11.2-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.2)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/bin/check-release-tar
+++ b/bin/check-release-tar
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Smoke-test a release tarball by unpacking it and running a real program
+# through its bundled launcher.
+#
+# Both install paths (docs/public/install.sh and `jo versions install`) now only
+# unpack the tarball and mark bin/jo executable -- they no longer rewrite the
+# launcher. So verifying the tarball verifies the installed result, and this
+# guards against incorrect packing when the build script changes.
+
+set -euo pipefail
+
+TARBALL="${1:?usage: bin/check-release-tar <jo-X.Y.Z.tar.gz>}"
+TARBALL="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
+
+BASE="$(basename "$TARBALL" .tar.gz)"   # jo-X.Y.Z
+VERSION="${BASE#jo-}"                    # X.Y.Z
+CONSTRAINT="$(echo "$VERSION" | cut -d. -f1,2)"  # X.Y
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+tar -xzf "$TARBALL" -C "$TMP"
+
+JO="$TMP/$BASE/bin/jo"
+if [ ! -x "$JO" ]; then
+  echo "[smoke] error: missing or non-executable launcher: $BASE/bin/jo"
+  exit 1
+fi
+
+# Minimal project that exercises the launcher, JO_HOME, and stdlib resolution.
+APP="$TMP/app"
+mkdir -p "$APP/src"
+cat > "$APP/jo.toml" <<EOF
+jo   = "$CONSTRAINT"
+name = "smoke"
+
+[main]
+target = "python"
+src    = ["src/"]
+EOF
+cat > "$APP/src/Main.jo" <<EOF
+def main(): Unit =
+  println: "smoke ok"
+EOF
+
+cd "$APP"
+if ! OUT="$("$JO" run 2>&1)"; then
+  echo "[smoke] error: 'jo run' failed for $BASE"
+  echo "-- output --"
+  echo "$OUT"
+  exit 1
+fi
+
+if ! echo "$OUT" | grep -q "smoke ok"; then
+  echo "[smoke] error: unexpected output from $BASE"
+  echo "-- output --"
+  echo "$OUT"
+  exit 1
+fi
+
+echo "[smoke] release tarball OK ($BASE)"

--- a/bin/install
+++ b/bin/install
@@ -43,57 +43,17 @@ confirm_remove() {
   esac
 }
 
-build_local() {
-  if [ "$BUILD_NATIVE" = true ]; then
-    echo "$(blue "Building Jo native launcher...")"
-    scala-cli --power package -f --native-image "$ROOT_DIR/project.scala" "$ROOT_DIR/stack-lang" -M cli.Main -o "$ROOT_DIR/bin/jo.native" -- --no-fallback
-
-    cat > "$ROOT_DIR/bin/jo" << 'EOF'
-#!/bin/bash
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-JO_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
-export JO_HOME
-exec "$SCRIPT_DIR/jo.native" "$@"
-EOF
-  else
-    echo "$(blue "Building Jo launcher...")"
-    scala-cli --power package -f "$ROOT_DIR/project.scala" "$ROOT_DIR/stack-lang" -M cli.Main -o "$ROOT_DIR/bin/jo.jar"
-
-    cat > "$ROOT_DIR/bin/jo" << 'EOF'
-#!/bin/bash
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-JO_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
-export JO_HOME
-exec java -jar "$SCRIPT_DIR/jo.jar" "$@"
-EOF
-  fi
-
-  chmod +x "$ROOT_DIR/bin/jo"
-
-  echo "$(blue "Building bundled libraries...")"
-  rm -rf "$ROOT_DIR/libs"
-
-  "$ROOT_DIR/bin/jo" compile --sast "$ROOT_DIR/libs/stdlib" --test-pickling --explicit-return-type --check-shadowing --no-stdlib \
-    "$ROOT_DIR"/lib/*.jo "$ROOT_DIR"/lib/**/*.jo
-
-  "$ROOT_DIR/bin/jo" compile --sast "$ROOT_DIR/libs/runtime-interpreter" --test-pickling --explicit-return-type --check-shadowing \
-    "$ROOT_DIR/runtime/Interpreter.jo"
-
-  "$ROOT_DIR/bin/jo" compile --sast "$ROOT_DIR/libs/runtime-javascript" --test-pickling --explicit-return-type --check-shadowing \
-    "$ROOT_DIR"/runtime/javascript/*.jo
-
-  "$ROOT_DIR/bin/jo" compile --sast "$ROOT_DIR/libs/runtime-ruby" --test-pickling --explicit-return-type --check-shadowing \
-    "$ROOT_DIR"/runtime/ruby/*.jo
-
-  "$ROOT_DIR/bin/jo" compile --sast "$ROOT_DIR/libs/runtime-python" --test-pickling --explicit-return-type --check-shadowing \
-    "$ROOT_DIR"/runtime/python/*.jo
-
-  "$ROOT_DIR/bin/jo" compile --sast "$ROOT_DIR/libs/runtime-native" --test-pickling --explicit-return-type --check-shadowing \
-    "$ROOT_DIR"/runtime/native/*.jo "$ROOT_DIR"/runtime/native/**/*.jo
-}
-
+# Build the compiler artifacts (launcher, payload, bundled libraries) via the
+# build script, the single source of truth for how a compiler is produced.
 echo "$(blue "Building Jo from source...")"
-build_local
+
+if [ "$BUILD_NATIVE" = true ]; then
+  PAYLOAD="jo.native"
+  ( cd "$ROOT_DIR" && ./build --native )
+else
+  PAYLOAD="jo.jar"
+  ( cd "$ROOT_DIR" && ./build --fat )
+fi
 
 VERSION="$("$ROOT_DIR/bin/jo" --version)"
 INSTALL_DIR="$HOME/.jo/compilers/$VERSION"
@@ -111,29 +71,11 @@ cp "$ROOT_DIR/LICENSE" "$INSTALL_DIR/LICENSE"
 cp -r "$ROOT_DIR/libs" "$INSTALL_DIR/"
 cp -r "$ROOT_DIR/assets" "$INSTALL_DIR/"
 
-if [ "$BUILD_NATIVE" = true ]; then
-  cp "$ROOT_DIR/bin/jo.native" "$INSTALL_BIN_DIR/jo.native"
-
-  cat > "$INSTALL_BIN_DIR/jo" << 'EOF'
-#!/bin/bash
-BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-JO_HOME="$(cd "$BIN_DIR/.." && pwd)"
-export JO_HOME
-exec "$BIN_DIR/jo.native" "$@"
-EOF
-else
-  cp "$ROOT_DIR/bin/jo.jar" "$INSTALL_BIN_DIR/jo.jar"
-
-  cat > "$INSTALL_BIN_DIR/jo" << 'EOF'
-#!/bin/bash
-BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-JO_HOME="$(cd "$BIN_DIR/.." && pwd)"
-export JO_HOME
-exec java -jar "$BIN_DIR/jo.jar" "$@"
-EOF
-fi
-
-chmod +x "$INSTALL_BIN_DIR/jo"
+# Reuse the launcher and payload produced by the build (same layout as the
+# release tarball: bin/jo runs the sibling bin/$PAYLOAD).
+cp "$ROOT_DIR/bin/jo" "$INSTALL_BIN_DIR/jo"
+cp "$ROOT_DIR/bin/$PAYLOAD" "$INSTALL_BIN_DIR/$PAYLOAD"
+chmod +x "$INSTALL_BIN_DIR/jo" "$INSTALL_BIN_DIR/$PAYLOAD"
 
 if [ -e "$ACTIVE_BIN" ] || [ -L "$ACTIVE_BIN" ]; then
   confirm_remove "$ACTIVE_BIN"

--- a/build
+++ b/build
@@ -20,10 +20,10 @@ for arg in "$@"; do
       ;;
     *)
       echo "Unknown option: $arg"
-      echo "Usage: ./build [-native] [-fat] [-release]"
-      echo "  -native     Build native executable (slower build, faster startup)"
-      echo "  -fat        Build fat JAR with all dependencies (JAR only)"
-      echo "  -release    Package release zip (requires -fat)"
+      echo "Usage: ./build [--native] [--fat] [--release]"
+      echo "  --native     Build native executable (slower build, faster startup)"
+      echo "  --fat        Build fat JAR with all dependencies (JAR only)"
+      echo "  --release    Package release zip (requires -fat)"
       exit 1
       ;;
   esac
@@ -129,6 +129,9 @@ if [ "$BUILD_RELEASE" = true ]; then
   rm -rf "$TEMP_DIR"
 
   sha256sum "$RELEASE_TARBALL" > "${RELEASE_TARBALL}.sha256"
+
+  echo "Smoke-testing release tarball..."
+  bin/check-release-tar "$RELEASE_TARBALL"
 
   echo "Release package created: ${RELEASE_TARBALL}"
   echo "Checksum:                 ${RELEASE_TARBALL}.sha256"

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -1,3 +1,4 @@
 {"version":"0.10.0","url":"https://github.com/typescope/jo/releases/download/v0.10.0/jo-0.10.0.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.10.0/jo-0.10.0.tar.gz.sha256","date":"2026-06-04"}
 {"version":"0.11.0","url":"https://github.com/typescope/jo/releases/download/v0.11.0/jo-0.11.0.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.0/jo-0.11.0.tar.gz.sha256","date":"2026-06-18"}
 {"version":"0.11.1","url":"https://github.com/typescope/jo/releases/download/v0.11.1/jo-0.11.1.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.1/jo-0.11.1.tar.gz.sha256","date":"2026-06-27"}
+{"version":"0.11.2","url":"https://github.com/typescope/jo/releases/download/v0.11.2/jo-0.11.2.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.2/jo-0.11.2.tar.gz.sha256","date":"2026-06-27"}

--- a/docs/usage/commands/versions.md
+++ b/docs/usage/commands/versions.md
@@ -65,16 +65,18 @@ jo versions remove 0.9.0
 Each version is installed under `~/.jo/compilers/<version>/`:
 
 ```
-~/.jo/compilers/0.10.0/
-  jo.jar
+~/.jo/compilers/0.11.1/
   bin/
     jo
+    jo.jar
   libs/
   assets/
   LICENSE
 ```
 
-The active launcher at `~/.local/bin/jo` delegates to the selected version's `bin/jo`.
+The launcher `bin/jo` sets `JO_HOME` to the version directory and runs the sibling
+`bin/jo.jar`. The active launcher at `~/.local/bin/jo` delegates to the selected
+version's `bin/jo`.
 
 ## See Also
 

--- a/stack-lang/tool/Installer.scala
+++ b/stack-lang/tool/Installer.scala
@@ -147,8 +147,7 @@ class HttpInstaller(
           else
             Files.createDirectories(installBase)
             moveDir(extracted, installDir)
-            writeLauncher(installDir)
-            Result.Ok(())
+            ensureLauncherExecutable(installDir)
       yield ()
     finally
       deleteDir(tmp)
@@ -169,18 +168,18 @@ class HttpInstaller(
     if code == 0 then Result.Ok(())
     else Result.Err(s"tar extraction failed (exit $code): $output")
 
-  private def writeLauncher(installDir: Path): Unit =
-    val bin = installDir.resolve("bin")
-    Files.createDirectories(bin)
-    val launcher = bin.resolve("jo")
-    Files.writeString(launcher,
-      s"""#!/bin/sh
-         |BIN_DIR="$$(cd "$$(dirname "$$0")" && pwd)"
-         |JO_HOME="$$(cd "$$BIN_DIR/.." && pwd)"
-         |export JO_HOME
-         |exec java -jar "$$JO_HOME/jo.jar" "$$@"
-         |""".stripMargin)
-    launcher.toFile.setExecutable(true)
+  /** The versioned launcher ships in the tarball at `bin/jo`, so it is the single
+   *  source of truth for the layout. Just ensure it is executable rather than
+   *  regenerating it (which would hardcode the jar path and drift from the tarball).
+   */
+  private def ensureLauncherExecutable(installDir: Path): Result[Unit] =
+    val launcher = installDir.resolve("bin").resolve("jo")
+
+    if !Files.exists(launcher) then
+      Result.Err("unexpected tarball layout: missing bin/jo launcher")
+    else
+      launcher.toFile.setExecutable(true)
+      Result.Ok(())
 
   private def fetchText(url: String): Result[String] =
     try

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 11, 1)
+  val current: Version = Version(0, 11, 2)


### PR DESCRIPTION
Fix jo self-version upgrade

## Summary

In last version, we changed the location of `jo.jar` from root directory to `bin/`. However, the integrated installer incorrectly assumes the wrong location of `jo.jar`.

We fix the installer by simplifying it: it suffices to just unpack the tar. We also added a smoke test for the tar in the release process.

The fix lands in `0.11.2`.

## Mitigation

This is a breaking change. Users cannot use `jo versions install` to install `0.11.1` or `0.11.2`. They need to use the script:

```
curl -sSf https://jo-lang.org/install.sh | sh
```
