### PR TITLE
Support custom subcommand for jo 

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -167,6 +167,7 @@ export default defineConfig({
             { text: 'jo clean', link: '/usage/commands/clean' },
             { text: 'jo compile', link: '/usage/commands/compile' },
             { text: 'jo versions', link: '/usage/commands/versions' },
+            { text: 'jo exec / jo <name>', link: '/usage/commands/exec' },
           ]
         }
       ],

--- a/docs/usage/commands/exec.md
+++ b/docs/usage/commands/exec.md
@@ -1,0 +1,61 @@
+# jo &lt;name&gt; / jo exec
+
+Run a project-defined command from the [`[commands]`](../reference/build-spec.md#commands-project-commands) table in `jo.toml`.
+
+## Usage
+
+```
+jo <name> [args...]        # built-in first, then a [commands] entry
+jo exec <name> [args...]   # always a [commands] entry, bypassing built-ins
+```
+
+## How It Works
+
+Commands are named shell aliases declared in `[commands]`:
+
+```toml
+[commands]
+dev = "jo build --spec sandbox/guest/jo.toml && jo run"
+fmt = "echo formatting..."
+```
+
+- **`jo <name>`** resolves built-in commands first (`build`, `run`, `test`, …), then falls back to a `[commands]` entry. Built-ins can never be shadowed by a project, so `jo build` is always the real build even if a `build` command is defined.
+- **`jo exec <name>`** skips built-ins and runs the `[commands]` entry directly. Use it when a command shares a name with a built-in, or to stay stable if a future Jo version adds a built-in of the same name.
+
+::: info Why built-ins take precedence — a deliberate design choice
+`jo <name>` resolves built-ins **before** project commands on purpose, so a `jo.toml` can never redefine `jo build`, `jo run`, or `jo test`. This keeps those commands safe to type in any directory: cloning an untrusted repository and running `jo build` will never execute shell defined in its manifest.
+
+The trade-off is intentional. Letting project commands override built-ins would be convenient, but to be useful an override must fire automatically whenever anyone types the verb — which is exactly what would turn `git clone && jo build` into arbitrary code execution.
+
+Consequently, commands run **only when you invoke them by name** — there are no install or lifecycle hooks that run on their own. To customize what a built-in does for a project, define a distinctly-named command (e.g. `dev`) and run `jo dev`, instead of shadowing the built-in.
+:::
+
+Each command runs through `sh -c` from the project root, so shell features like `&&` and pipes work. Extra arguments are appended to the command line, and the command's exit status becomes `jo`'s exit status.
+
+```sh
+jo dev              # runs: jo build --spec sandbox/guest/jo.toml && jo run
+jo dev --port 8080  # appends `--port 8080`
+jo exec build       # runs the [commands] "build", not the built-in
+```
+
+## Errors
+
+If neither a built-in nor a defined command matches, `jo` reports it and lists the available commands:
+
+```
+$ jo bogus
+Error: unknown command 'bogus'
+Defined commands: dev, fmt
+```
+
+## Examples
+
+```sh
+jo dev
+jo fmt
+jo exec dev
+```
+
+## See Also
+
+- [`[commands]`](../reference/build-spec.md#commands-project-commands) — declaring commands in `jo.toml`.

--- a/docs/usage/commands/index.md
+++ b/docs/usage/commands/index.md
@@ -15,6 +15,7 @@
 | [`jo clean`](clean.md) | Remove build artifacts |
 | [`jo versions`](versions.md) | Manage compiler versions |
 | [`jo compile`](compile.md) | Raw compiler interface |
+| [`jo <name>` / `jo exec`](exec.md) | Run a project command from `[commands]` |
 
 ## Global Options
 

--- a/docs/usage/reference/build-spec.md
+++ b/docs/usage/reference/build-spec.md
@@ -93,3 +93,27 @@ Explicit wiring of `defer def`s. All entries are required — unresolved `defer 
 ```
 
 `[test.links]` is merged with `[main.links]`. Test overrides take precedence.
+
+## `[commands]` — Project Commands
+
+Named shell commands you invoke as `jo <name>` — the project's command palette, comparable to `npm run` scripts. Each value is a command line run through the system shell (`sh -c`) from the project root.
+
+```toml
+[commands]
+dev    = "jo build --spec sandbox/guest/jo.toml && jo run"
+fmt    = "jo compile --doc src/ --out api"
+deploy = "./scripts/deploy.sh"
+```
+
+Invoke by name; any extra arguments are appended:
+
+```sh
+jo dev
+jo dev --port 8080     # runs the command with `--port 8080` appended
+```
+
+Built-in commands always win: if a command shares a name with a built-in (e.g. `build`), `jo build` runs the built-in, so a project can never shadow Jo's own verbs. Use [`jo exec <name>`](../commands/exec.md) to run a defined command unambiguously. Commands run only when invoked — there are no install/lifecycle hooks that run automatically.
+
+::: info Design choice: built-ins are unshadowable
+This precedence is a deliberate security decision — it keeps `jo build`/`jo run`/`jo test` safe to run in an untrusted checkout. See [Why built-ins take precedence](../commands/exec.md#how-it-works) for the rationale.
+:::

--- a/stack-lang/cli/Main.scala
+++ b/stack-lang/cli/Main.scala
@@ -134,13 +134,52 @@ object Main:
       case "help" | "--help" | "-h" =>
         printUsage()
 
+      case "exec" =>
+        // Always run a project-defined command, bypassing builtins.
+        val rest = args.drop(1)
+        if rest.isEmpty then
+          println("Error: 'exec' requires a command name")
+          System.exit(1)
+        else
+          runProjectCommand(rest(0), rest.drop(1), forced = true)
+
       case file if file.endsWith(".jo") =>
         // Default to eval if a .jo file is provided directly
         sast.Interpreter.main(args)
 
-      case _ =>
-        println(s"Error: Unknown command '${args(0)}'")
-        printUsage()
+      case name =>
+        // Not a builtin: as a last resort, try a project-defined [commands] entry.
+        runProjectCommand(name, args.drop(1), forced = false)
+
+  /** Run a `[commands]` entry from the current project's jo.toml, passing any
+   *  extra args through. `forced` marks the explicit `jo exec` form (builtins
+   *  already ruled out); when false this is the `jo <name>` fallthrough, so a miss
+   *  reports an unknown command. Exits with the command's status.
+   */
+  private def runProjectCommand(name: String, extra: Array[String], forced: Boolean): Unit =
+    tool.Project.loadSpec(Paths.get("").toAbsolutePath) match
+      case tool.Result.Ok(spec) =>
+        spec.commands.get(name) match
+          case Some(cmd) =>
+            val full = if extra.isEmpty then cmd else s"$cmd ${extra.mkString(" ")}"
+            val code = ProcessBuilder("sh", "-c", full).inheritIO().start().waitFor()
+            System.exit(code)
+
+          case None =>
+            System.err.println(s"Error: unknown command '$name'")
+            if spec.commands.nonEmpty then
+              System.err.println(s"Defined commands: ${spec.commands.keys.toSeq.sorted.mkString(", ")}")
+            else if !forced then
+              printUsage()
+            System.exit(1)
+
+      case tool.Result.Err(msg) =>
+        // No (or invalid) project here: `exec` surfaces why; the bare fallthrough
+        // just reports an unknown command as before.
+        if forced then System.err.println(s"Error: cannot run '$name': $msg")
+        else
+          println(s"Error: Unknown command '$name'")
+          printUsage()
         System.exit(1)
 
   enum Backend:
@@ -208,6 +247,8 @@ object Main:
       |  jo lock [--spec <file.toml>]           Resolve dependencies and rewrite the lock file
       |  jo info <pkg>[@<version>]              Show package metadata and available versions
       |  jo eval <source.jo>                    Run program with interpreter
+      |  jo <name> [args...]                    Run a project command from [commands] (builtins win)
+      |  jo exec <name> [args...]               Run a [commands] entry, bypassing builtins
       |  jo versions                             List installed and available compiler versions
       |  jo versions install <version>          Download and install a compiler version
       |  jo versions use <version>              Switch the active compiler version

--- a/stack-lang/cli/Main.scala
+++ b/stack-lang/cli/Main.scala
@@ -161,8 +161,21 @@ object Main:
       case tool.Result.Ok(spec) =>
         spec.commands.get(name) match
           case Some(cmd) =>
-            val full = if extra.isEmpty then cmd else s"$cmd ${extra.mkString(" ")}"
-            val code = ProcessBuilder("sh", "-c", full).inheritIO().start().waitFor()
+            // The command string is run through the shell, so `&&`, pipes, etc.
+            // in the *definition* work. Extra CLI args are appended as literal
+            // positional parameters via "$@" — never spliced into the shell text
+            // — so a metacharacter in an argument (`jo dev "&& rm -rf /"`) is
+            // passed as data, not executed.
+            //
+            // In `sh -c <script> A B C`, the argument after the script becomes
+            // `$0`, and only the rest become `$1`, `$2`, … (what "$@" expands
+            // to). So a placeholder must occupy `$0`, or the first real arg would
+            // be swallowed and dropped from "$@". We use "jo" as that `$0` so any
+            // shell diagnostics are attributed to `jo` (e.g. `jo: line 1: …`).
+            val argv =
+              if extra.isEmpty then List("sh", "-c", cmd)
+              else List("sh", "-c", cmd + " \"$@\"", "jo") ++ extra.toList
+            val code = ProcessBuilder(argv*).inheritIO().start().waitFor()
             System.exit(code)
 
           case None =>

--- a/stack-lang/tool/BuildSpec.scala
+++ b/stack-lang/tool/BuildSpec.scala
@@ -51,6 +51,7 @@ case class BuildSpec(
   doc: Option[DocSpec],
   main: ModuleSpec,
   test: Option[ModuleSpec],
+  commands: Map[String, String] = Map.empty, // [commands] → `jo <name>` shell aliases
 ):
   def isLib: Boolean = pkg.isDefined
 
@@ -69,8 +70,17 @@ object BuildSpec:
     val mainTbl = doc.get("main").map(asTbl(_, "main")).getOrElse(Map.empty)
     val main    = decodeSection(mainTbl, "main")
     val test    = doc.get("test").map(v => decodeSection(asTbl(v, "test"), "test"))
+    val commands = doc.get("commands").map(v => decodeCommands(asTbl(v, "commands"))).getOrElse(Map.empty)
 
-    BuildSpec(jo, name, depth, pinning, pkg, docSpec, main, test)
+    BuildSpec(jo, name, depth, pinning, pkg, docSpec, main, test, commands)
+
+  private def decodeCommands(tbl: Map[String, TomlValue]): Map[String, String] =
+    tbl.map: (name, value) =>
+      val cmd = asStr(value, s"[commands].$name")
+      if cmd.trim.isEmpty then
+        throw TomlError(s"[commands].$name must be a non-empty command string")
+      name -> cmd
+    .toMap
 
   private def decodePinning(tbl: Map[String, TomlValue]): Map[String, Version] =
     tbl.toSeq.sortBy(_._1).map: (name, value) =>

--- a/stack-lang/tool/Project.scala
+++ b/stack-lang/tool/Project.scala
@@ -45,6 +45,8 @@ final class Project private (
 
   def test: Option[ModuleSpec] = spec.test
 
+  def commands: Map[String, String] = spec.commands
+
   def runtime: Option[String] = spec.pkg.flatMap(_.runtime)
 
   /** Root of this project's build output: `<dir>/.build/<name>/`. */

--- a/stack-lang/tool/ToolPrinter.scala
+++ b/stack-lang/tool/ToolPrinter.scala
@@ -37,6 +37,11 @@ object ToolPrinter:
         sb.append("test:\n")
         appendSection(sb, t, "  ")
 
+    if spec.commands.nonEmpty then
+      sb.append("commands:\n")
+      for (name, cmd) <- spec.commands.toSeq.sortBy(_._1) do
+        sb.append(s"  $name = ${str(cmd)}\n")
+
     sb.toString.stripTrailing()
 
   def print(lock: LockFile): String =

--- a/tests/custom/build-commands/jo.toml
+++ b/tests/custom/build-commands/jo.toml
@@ -2,5 +2,6 @@ jo   = "0.11"
 name = "commands-demo"
 
 [commands]
-dev  = "echo hi-dev"
-help = "echo SHADOWED-HELP"
+dev   = "echo hi-dev"
+help  = "echo SHADOWED-HELP"
+fails = "echo before-failure; exit 3"

--- a/tests/custom/build-commands/jo.toml
+++ b/tests/custom/build-commands/jo.toml
@@ -1,0 +1,6 @@
+jo   = "0.11"
+name = "commands-demo"
+
+[commands]
+dev  = "echo hi-dev"
+help = "echo SHADOWED-HELP"

--- a/tests/custom/build-commands/test.sh
+++ b/tests/custom/build-commands/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Project [commands]: `jo <name>` runs a defined command (built-ins win), while
+# `jo exec <name>` always runs the command, bypassing built-ins.
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_NAME="$(basename "$DIR")"
+PROJECT_ROOT="$(cd "$DIR/../../.." && pwd)"
+JO="${JO_BIN:-$PROJECT_ROOT/bin/jo}"
+
+echo "Testing $TEST_NAME"
+cd "$DIR"
+
+fail() { echo "[error] $TEST_NAME: $1"; echo "-- stdout --"; cat out.txt 2>/dev/null; echo "-- stderr --"; cat err.txt 2>/dev/null; rm -f out.txt err.txt; exit 1; }
+
+# 1. `jo <name>` falls through to a [commands] entry.
+"$JO" dev >out.txt 2>err.txt || fail "jo dev failed"
+grep -q "hi-dev" out.txt || fail "jo dev did not run the command"
+
+# 2. Extra arguments are appended to the command.
+"$JO" dev alpha beta >out.txt 2>err.txt || fail "jo dev alpha beta failed"
+grep -q "hi-dev alpha beta" out.txt || fail "jo dev did not pass args through"
+
+# 3. `jo exec <name>` runs the command.
+"$JO" exec dev >out.txt 2>err.txt || fail "jo exec dev failed"
+grep -q "hi-dev" out.txt || fail "jo exec dev did not run the command"
+
+# 4. Built-ins win: 'help' is defined as a command AND is a built-in;
+#    `jo help` must run the built-in (print usage), not the command.
+"$JO" help >out.txt 2>err.txt || fail "jo help failed"
+grep -q "Usage:" out.txt || fail "jo help did not run the built-in"
+grep -q "SHADOWED-HELP" out.txt && fail "jo help ran the command instead of the built-in"
+
+# 5. `jo exec` forces the command even when a built-in shares the name.
+"$JO" exec help >out.txt 2>err.txt || fail "jo exec help failed"
+grep -q "SHADOWED-HELP" out.txt || fail "jo exec help did not run the command"
+
+# 6. An unknown command fails and lists the defined commands.
+if "$JO" bogus >out.txt 2>err.txt; then fail "jo bogus should have failed"; fi
+grep -q "unknown command 'bogus'" err.txt || fail "missing unknown-command error"
+grep -q "Defined commands:" err.txt || fail "did not list defined commands"
+
+rm -f out.txt err.txt
+echo "  ✓ All tests passed for $TEST_NAME"

--- a/tests/custom/build-commands/test.sh
+++ b/tests/custom/build-commands/test.sh
@@ -24,6 +24,12 @@ grep -q "hi-dev alpha beta" out.txt || fail "jo dev did not pass args through"
 "$JO" exec dev >out.txt 2>err.txt || fail "jo exec dev failed"
 grep -q "hi-dev" out.txt || fail "jo exec dev did not run the command"
 
+# 3b. Extra args are literal data — shell metacharacters are NOT interpreted.
+#     `jo dev "&& echo INJECTED"` must print the text, not run a second command.
+"$JO" dev "&& echo INJECTED" >out.txt 2>err.txt || fail "jo dev with metachars failed"
+grep -q -- "hi-dev && echo INJECTED" out.txt || fail "argument was not passed literally"
+grep -qx "INJECTED" out.txt && fail "argument was shell-injected (ran as a second command)"
+
 # 4. Built-ins win: 'help' is defined as a command AND is a built-in;
 #    `jo help` must run the built-in (print usage), not the command.
 "$JO" help >out.txt 2>err.txt || fail "jo help failed"

--- a/tests/custom/build-commands/test.sh
+++ b/tests/custom/build-commands/test.sh
@@ -45,5 +45,23 @@ if "$JO" bogus >out.txt 2>err.txt; then fail "jo bogus should have failed"; fi
 grep -q "unknown command 'bogus'" err.txt || fail "missing unknown-command error"
 grep -q "Defined commands:" err.txt || fail "did not list defined commands"
 
+# 7. A command's exit status propagates, so shell `&&`/`||`/`set -e` and CI see
+#    failures. `fails` runs then exits 3; jo must exit 3 too.
+"$JO" fails >out.txt 2>err.txt
+code=$?
+[ "$code" -eq 3 ] || fail "exit status not propagated (expected 3, got $code)"
+grep -q "before-failure" out.txt || fail "command ran but its output was lost"
+
+# 8. Shell chaining: the `&&` here is the invoking shell's, not jo's. jo exits 0
+#    after a successful command, so the right-hand side runs.
+{ "$JO" dev && echo success; } >out.txt 2>err.txt || fail "jo dev && echo success failed"
+grep -q "hi-dev" out.txt  || fail "jo dev output missing in the && chain"
+grep -q "success" out.txt || fail "&& did not run after a successful jo dev"
+
+# 8b. And it short-circuits: a failing command's nonzero exit stops the chain.
+{ "$JO" fails && echo should-not-run; } >out.txt 2>err.txt
+grep -q "before-failure" out.txt   || fail "jo fails did not run in the && chain"
+grep -q "should-not-run" out.txt   && fail "&& ran the RHS despite jo fails exiting nonzero"
+
 rm -f out.txt err.txt
 echo "  ✓ All tests passed for $TEST_NAME"

--- a/tests/tool-toml/build-spec/commands.toml
+++ b/tests/tool-toml/build-spec/commands.toml
@@ -1,0 +1,9 @@
+jo = "1.0"
+name = "cmd-app"
+
+[main]
+target = "python"
+
+[commands]
+dev = "jo build --spec sandbox/guest/jo.toml && jo run"
+fmt = "echo formatting"

--- a/tests/tool-toml/build-spec/commands.txt
+++ b/tests/tool-toml/build-spec/commands.txt
@@ -1,0 +1,10 @@
+jo = "1.0"
+name = "cmd-app"
+build = app
+main:
+  src = (default)
+  target = "python"
+test = none
+commands:
+  dev = "jo build --spec sandbox/guest/jo.toml && jo run"
+  fmt = "echo formatting"


### PR DESCRIPTION
Support custom subcommand for Jo

## Summary

Allow users to define commands in .toml specs:

```
[commands]
dev = "jo build --spec sandbox/guest/jo.toml && jo run"
fmt = "echo formatting..."
```

In handling `jo <subcommand>`, the builtin commands will take precedence. Users can use `jo exec <command>` to invoke the custom commands.

The additional arguments pass through.

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

The design intentionally favors security over flexibility. See the documentation.
