### PR TITLE
Release 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.3] - 2026-07-01
+
+### Added
+
+- Custom commands: a `[commands]` table in `jo.toml` defines named shell
+  commands, run as `jo <name>` (built-ins take precedence) or `jo exec <name>`
+  (bypassing built-ins). ([#41])
+
+### Fixed
+
+- Test builds now respect the test module's `compile-options`. ([#40])
+
+[#40]: https://github.com/typescope/jo/pull/40
+[#41]: https://github.com/typescope/jo/pull/41
+
 ## [0.11.2] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.11.2-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.2)
+  [![Release](https://img.shields.io/badge/release-v0.11.3-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.3)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -2,3 +2,4 @@
 {"version":"0.11.0","url":"https://github.com/typescope/jo/releases/download/v0.11.0/jo-0.11.0.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.0/jo-0.11.0.tar.gz.sha256","date":"2026-06-18"}
 {"version":"0.11.1","url":"https://github.com/typescope/jo/releases/download/v0.11.1/jo-0.11.1.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.1/jo-0.11.1.tar.gz.sha256","date":"2026-06-27"}
 {"version":"0.11.2","url":"https://github.com/typescope/jo/releases/download/v0.11.2/jo-0.11.2.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.2/jo-0.11.2.tar.gz.sha256","date":"2026-06-27"}
+{"version":"0.11.3","url":"https://github.com/typescope/jo/releases/download/v0.11.3/jo-0.11.3.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.3/jo-0.11.3.tar.gz.sha256","date":"2026-07-01"}

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 11, 2)
+  val current: Version = Version(0, 11, 3)


### PR DESCRIPTION
Patch release **0.11.3**.

### Changelog (0.11.3)
- **Added** — Custom commands: a `[commands]` table in `jo.toml`, run as `jo <name>` (built-ins take precedence) or `jo exec <name>` (bypassing built-ins). (#41)
- **Fixed** — Test builds now respect the test module's `compile-options`. (#40)

### This PR
- Bump `JoVersion` to `0.11.3`
- Update the README release badge, `CHANGELOG.md`, and `docs/public/versions.jsonl`

`bin/jo.dev --version` → `0.11.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)