### PR TITLE
Fix compilation command in the DB-query-agent example

### DIFF
--- a/demos/data-query-agent/agent.py
+++ b/demos/data-query-agent/agent.py
@@ -259,11 +259,11 @@ def compile_code(code: str) -> tuple[bool, str]:
 
     cmd = [
         os.path.join(PROJECT_ROOT, "bin", "jo"),
-        "build", "-python",
-        "-link", "jo.main=DatabaseRuntime.platformMain",
-        "-link", "DatabaseAPI.analyzeDocuments=UserTask.analyzeDocuments",
-        "-lib", os.path.join(OUT_DIR, "api"),
-        "-runtime", os.path.join(OUT_DIR, "runtime"),
+        "compile", "--python",
+        "--link", "jo.main=DatabaseRuntime.platformMain",
+        "--link", "DatabaseAPI.analyzeDocuments=UserTask.analyzeDocuments",
+        "--lib", os.path.join(OUT_DIR, "api"),
+        "--link-lib", os.path.join(OUT_DIR, "runtime"),
         TASK_JO,
         "-o", TASK_PY,
     ]

--- a/demos/sandbox-agent/agent.py
+++ b/demos/sandbox-agent/agent.py
@@ -263,11 +263,11 @@ def compile_code(code: str) -> tuple[bool, str]:
 
     cmd = [
         os.path.join(PROJECT_ROOT, "bin", "jo"),
-        "build", "-python",
-        "-link", "jo.main=AgentRuntime.platformMain",
-        "-link", "AgentAPI.runTask=UserTask.runTask",
-        "-lib", os.path.join(OUT_DIR, "api"),
-        "-runtime", os.path.join(OUT_DIR, "runtime"),
+        "compile", "--python",
+        "--link", "jo.main=DatabaseRuntime.platformMain",
+        "--link", "DatabaseAPI.analyzeDocuments=UserTask.analyzeDocuments",
+        "--lib", os.path.join(OUT_DIR, "api"),
+        "--link-lib", os.path.join(OUT_DIR, "runtime"),
         TASK_JO,
         "-o", TASK_PY,
     ]


### PR DESCRIPTION
It seems the compilation command is outdated leading to an obscure infinite loop in the agent.py accumulating "compilation failures".

With these options (borrowed from the build.sh script) the script worked (although I had to adapt it for OpenRouter/OpenAI API).