### PR TITLE
Consolidate compile options

### DIFF
--- a/build
+++ b/build
@@ -85,23 +85,23 @@ bin/jo compile --verbose --sast $STDLIB --test-pickling --explicit-return-type -
 
 # build interpreter runtime
 INT_RUNTIME=libs/runtime-interpreter
-bin/jo compile --verbose --sast $INT_RUNTIME --test-pickling --explicit-return-type --check-shadowing runtime/Interpreter.jo
+bin/jo compile --verbose --sast $INT_RUNTIME --test-pickling --explicit-return-type --no-star-import --check-shadowing runtime/Interpreter.jo
 
 # build JS runtime
 JS_RUNTIME=libs/runtime-javascript
-bin/jo compile --verbose --sast $JS_RUNTIME --test-pickling --explicit-return-type --check-shadowing runtime/javascript/*.jo
+bin/jo compile --verbose --sast $JS_RUNTIME --test-pickling --explicit-return-type --no-star-import --check-shadowing runtime/javascript/*.jo
 
 # build Ruby runtime
 RUBY_RUNTIME=libs/runtime-ruby
-bin/jo compile --verbose --sast $RUBY_RUNTIME --test-pickling --explicit-return-type --check-shadowing runtime/ruby/*.jo
+bin/jo compile --verbose --sast $RUBY_RUNTIME --test-pickling --explicit-return-type --no-star-import --check-shadowing runtime/ruby/*.jo
 
 # build Python runtime
 PYTHON_RUNTIME=libs/runtime-python
-bin/jo compile --verbose --sast $PYTHON_RUNTIME --test-pickling --explicit-return-type --check-shadowing runtime/python/*.jo
+bin/jo compile --verbose --sast $PYTHON_RUNTIME --test-pickling --explicit-return-type --no-star-import --check-shadowing runtime/python/*.jo
 
 # build native runtime
 NATIVE_RUNTIME=libs/runtime-native
-bin/jo compile --verbose --sast $NATIVE_RUNTIME --test-pickling --explicit-return-type --check-shadowing runtime/native/*.jo runtime/native/**/*.jo
+bin/jo compile --verbose --sast $NATIVE_RUNTIME --test-pickling --explicit-return-type --no-star-import --check-shadowing runtime/native/*.jo runtime/native/**/*.jo
 
 # Package release if requested
 if [ "$BUILD_RELEASE" = true ]; then

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -145,6 +145,7 @@ export default defineConfig({
           text: 'Reference',
           items: [
             { text: 'Build Spec', link: '/usage/reference/build-spec' },
+            { text: 'Compiler Options', link: '/usage/reference/compiler-options' },
             { text: 'Library Metadata', link: '/usage/reference/library-metadata' },
             { text: 'Dependency Resolution', link: '/usage/reference/dependency-resolution' },
             { text: 'Registry', link: '/usage/reference/registry' },

--- a/docs/usage/commands/compile.md
+++ b/docs/usage/commands/compile.md
@@ -9,19 +9,24 @@ Raw compiler interface. No project spec required.
 jo compile [--sast <dir>] <file.jo>... [--lib <dir>]...
 
 # Compile to executable or script
-jo compile --python|--ruby|--js|--stack|--reg [--sast <dir>] <file.jo>... \
+jo compile --python|--ruby|--js [--sast <dir>] <file.jo>... \
            [--lib <dir>]... [--link-lib <dir>]... [--link <src>=<tgt>]... -o <output>
 
-# Generate documentation from source files
-jo compile --doc [--out <dir>] [--title <name>] [--include-private] [--include-source] \
-           <file.jo>...
+# Generate documentation from source files (experimental)
+jo compile --doc [--out <dir>] [--title <name>] [--readme <file>] \
+           [--include-private] [--include-source] <file.jo>...
 ```
 
 Without a backend flag, the compiler type-checks only. With a backend flag, it produces an executable or script. `--sast <dir>` is optional in both cases — if present, `.sast` files are written to `<dir>` alongside the primary output.
 
-`--doc` switches the compiler into primitive documentation mode. This is the low-level interface for generating docs directly from source files. For normal project workflows, prefer [`jo doc`](doc.md).
+`--doc` is an experimental low-level interface for generating docs directly from
+source files. It may change. For normal project workflows, prefer [`jo doc`](doc.md).
 
 ## Options
+
+This page lists the main user-facing options. For the full low-level option set,
+including stricter checking and compiler-development flags, see
+[Compiler Options](../reference/compiler-options.md).
 
 ### Common
 
@@ -34,11 +39,14 @@ Without a backend flag, the compiler type-checks only. With a backend flag, it p
 
 ### Documentation
 
+Experimental.
+
 | Flag | Description |
 |------|-------------|
 | `--doc` | Generate documentation instead of normal compile output |
 | `--out <dir>` | Documentation output directory |
 | `--title <name>` | Documentation title |
+| `--readme <file>` | Markdown file to use as the generated documentation home page |
 | `--include-private` | Include private symbols |
 | `--include-source` | Embed source code in output |
 
@@ -49,7 +57,6 @@ Without a backend flag, the compiler type-checks only. With a backend flag, it p
 | `--ruby`                  | Target Ruby (default) |
 | `--python`                | Target Python |
 | `--js`                    | Target JavaScript (experimental) |
-| `--stack\|--reg`          | Target native backend (internal testing) |
 | `--link-lib <dir>`        | Link library directory (resolves `defer def`s, can be repeated) |
 | `--link <src>=<tgt>`      | Wire a specific `defer def` explicitly (can be repeated) |
 | `-o <output>`             | Output file path |

--- a/docs/usage/commands/doc.md
+++ b/docs/usage/commands/doc.md
@@ -45,4 +45,4 @@ jo doc
 jo doc --spec agent-api.toml
 ```
 
-For the primitive source-file interface, use [`jo compile --doc`](compile.md).
+The primitive source-file interface, [`jo compile --doc`](compile.md), is experimental.

--- a/docs/usage/reference/build-spec.md
+++ b/docs/usage/reference/build-spec.md
@@ -47,7 +47,7 @@ Presence of this section marks the build as a **library**. Publishing metadata f
 | `src`             | array of globs   | no       | Source files. Default: `["src/**/*.jo"]`. |
 | `target`          | string           | no       | Backend: `"python"`, `"ruby"`. Default: `"python"`. |
 | `depth`           | integer          | no       | Maximum allowed package-dependency tree height for the main module. Overrides the top-level `depth`. If absent, `main` inherits the project-level `depth`, or defaults to `0` for libraries and `1` for apps. Local `path` projects do not count toward this value. See [Dependency Resolution](dependency-resolution.md). |
-| `compile-options` | array of strings | no       | Extra flags passed verbatim to `jo compile` when building this module. For example, `["--no-stdlib"]` is used when building the standard library itself. This can still be used to request a specific runtime API manually when needed. |
+| `compile-options` | array of strings | no       | Extra flags passed verbatim to `jo compile` when building this module. For example, `["--no-stdlib"]` is used when building the standard library itself. This can still be used to request a specific runtime API manually when needed. See [Compiler Options](compiler-options.md). |
 
 ## `[test]` — Test Source
 
@@ -101,7 +101,6 @@ Named shell commands you invoke as `jo <name>` — the project's command palette
 ```toml
 [commands]
 dev    = "jo build --spec sandbox/guest/jo.toml && jo run"
-fmt    = "jo compile --doc src/ --out api"
 deploy = "./scripts/deploy.sh"
 ```
 

--- a/docs/usage/reference/compiler-options.md
+++ b/docs/usage/reference/compiler-options.md
@@ -28,7 +28,6 @@ Backend selectors are handled before the shared compiler options are parsed.
 | `--ruby` | Compile a Ruby application. |
 | `--python` | Compile a Python application. |
 | `--js` | Compile a JavaScript application. Experimental. |
-| `--doc` | Generate API documentation instead of normal compile output. Experimental. |
 
 ## Common Options
 

--- a/docs/usage/reference/compiler-options.md
+++ b/docs/usage/reference/compiler-options.md
@@ -57,6 +57,7 @@ These options enable stricter compile-time checks.
 | `--explicit-return-type` | flag | Require functions to declare an explicit return type. |
 | `--check-shadowing` | flag | Report shadowing of local definitions. |
 | `--explicit-this` | flag | Require method calls and field accesses on the current receiver to be written with an explicit `this.` selection. |
+| `--no-star-import` | flag | Forbid wildcard imports such as `import foo.*`. |
 
 ## App Compilation Options
 

--- a/docs/usage/reference/compiler-options.md
+++ b/docs/usage/reference/compiler-options.md
@@ -1,0 +1,101 @@
+# Compiler Options Reference
+
+These are the low-level options accepted by `jo compile`. Project commands such as
+`jo build`, `jo check`, `jo test`, and `jo run` usually derive compiler flags from
+`jo.toml`, but `[main].compile-options` can pass extra flags through to `jo compile`.
+
+For the command-level interface and examples, see [`jo compile`](../commands/compile.md).
+
+## Option Forms
+
+| Form | Meaning |
+|------|---------|
+| flag | Boolean option with no value, for example `--verbose`. |
+| single value | Option followed by one value, for example `--sast .build/sast`. |
+| repeatable value | Option may appear multiple times, for example `--lib core --lib util`. |
+| comma list | One value split on commas, for example `--print-after namer,typer`. |
+
+Boolean and single-value options warn if specified more than once. Repeatable options
+preserve the command-line order after parsing.
+
+## Backend Selection
+
+Backend selectors are handled before the shared compiler options are parsed.
+
+| Option | Description |
+|--------|-------------|
+| no backend selector | Type-check only. No executable or script is generated. |
+| `--ruby` | Compile a Ruby application. |
+| `--python` | Compile a Python application. |
+| `--js` | Compile a JavaScript application. Experimental. |
+| `--doc` | Generate API documentation instead of normal compile output. Experimental. |
+
+## Common Options
+
+Common options are accepted by type-check-only compilation, app backend compilation,
+and experimental documentation generation.
+
+| Option | Form | Description |
+|--------|------|-------------|
+| `--verbose` | flag | Show verbose compiler output. |
+| `--fatal-warnings` | flag | Treat warnings as fatal. |
+| `--no-stdlib` | flag | Do not load the standard library automatically. |
+| `--lib <dir>` | repeatable value | Add a precompiled check-library directory. Each path must exist. |
+| `--sast <dir>` | single value | Write `.sast` files to the given directory. |
+| `--use-runtime-api <runtime>` | single value | Make a runtime API available as a check library. Accepted values are `python`, `ruby`, and `js`. |
+
+When `--use-runtime-api` matches the selected app backend, the app compiler uses that
+runtime API as a check library and suppresses the backend's default runtime link library.
+`js` is experimental.
+
+## Additional Checks
+
+These options enable stricter compile-time checks.
+
+| Option | Form | Description |
+|--------|------|-------------|
+| `--explicit-return-type` | flag | Require functions to declare an explicit return type. |
+| `--check-shadowing` | flag | Report shadowing of local definitions. |
+| `--explicit-this` | flag | Require method calls and field accesses on the current receiver to be written with an explicit `this.` selection. |
+
+## App Compilation Options
+
+These options are accepted when compiling an application with an app backend such as
+`--python`, `--ruby`, or `--js`.
+
+| Option | Form | Description |
+|--------|------|-------------|
+| `-o <file>` | single value | Output file path. |
+| `--link-lib <dir>` | repeatable value | Add a link-library directory used to resolve deferred definitions. Each path must exist. |
+| `--link <source=target>` | repeatable value | Redirect symbol references from `source` to `target`. |
+
+`--link` values must use `source=target` format. Both sides must be names or
+dot-separated paths whose segments are identifiers, such as
+`jo.Predef.entry=App.main`.
+
+## Compiler Development Options
+
+These options are mostly useful when working on the compiler itself.
+
+| Option | Form | Description |
+|--------|------|-------------|
+| `--show-steps` | flag | Print each compiler step before it runs. |
+| `--report-time` | flag | Print the compiler timing report. |
+| `--check-tree` | flag | Check trees after each phase. |
+| `--test-pickling` | flag | Exercise pickling as part of the compile. |
+| `--print-before <steps>` | comma list | Print compiler output before the named steps. |
+| `--print-after <steps>` | comma list | Print compiler output after the named steps. |
+| `--print-only <filters>` | comma list | Limit `--print-before` and `--print-after` output to source files whose path contains one of the listed filters. |
+
+## Documentation Options
+
+`jo compile --doc` is experimental and may change. It accepts the common options
+above plus these documentation-specific options.
+
+| Option | Form | Description |
+|--------|------|-------------|
+| `--out <dir>` | single value | Documentation output directory. Default: `docs`. |
+| `--title <name>` | single value | Documentation title. Default: `API Documentation`. |
+| `--readme <file>` | single value | Markdown file to use as the generated documentation home page. |
+| `--include-private` | flag | Include private symbols. |
+| `--include-source` | flag | Embed source code in the generated documentation. |

--- a/runtime/native/regex/Ast.jo
+++ b/runtime/native/regex/Ast.jo
@@ -1,0 +1,23 @@
+namespace jo.runtime.native.regex
+
+section Ast
+  class CharClass(chars: List[Char], ranges: List[Char ~ Char], negated: Bool)
+  object Dot
+
+  type Atom = Char | Dot | CharClass
+
+  class CaptureId(index: Int, name: Option[String])
+
+  union Pattern =
+      EmptyP
+    | AtomP(a: Atom)
+    | Seq(p1: Pattern, p2: Pattern)
+    | Or(p1: Pattern, p2: Pattern)
+    | Star(p: Pattern, greedy: Bool)
+    | Optional(p: Pattern, greedy: Bool)
+    | Capture(id: CaptureId, p: Pattern)
+    | StartP
+    | EndP
+    | WordBoundaryP
+    | NotWordBoundaryP
+end

--- a/runtime/native/regex/Engine.jo
+++ b/runtime/native/regex/Engine.jo
@@ -1,7 +1,7 @@
 namespace jo.runtime.native.regex
 
 import jo.runtime.native
-import jo.runtime.native.regex.Ast.*
+import jo.runtime.native.regex.Ast
 
 class Segment(from: Int, to: Int)
 
@@ -18,7 +18,7 @@ section Engine
   class Thread
     var start: Int
     var step: Int
-    var captureStack: List[CaptureId ~ Int]
+    var captureStack: List[Ast.CaptureId ~ Int]
     var indexed: Array[Option[Segment]]
     var named: Map[String, Segment]
     var priority: List[Int]
@@ -26,7 +26,7 @@ section Engine
     def Thread(
         start: Int,
         step: Int,
-        captureStack: List[CaptureId ~ Int],
+        captureStack: List[Ast.CaptureId ~ Int],
         indexed: Array[Option[Segment]],
         named: Map[String, Segment],
         priority: List[Int]) =
@@ -92,10 +92,10 @@ section Engine
         found = true
     found
 
-  def enterCapture(t: Thread, id: CaptureId, pos: Int): Unit =
+  def enterCapture(t: Thread, id: Ast.CaptureId, pos: Int): Unit =
     t.captureStack = t.captureStack + (id ~ pos)
 
-  def exitCapture(t: Thread, id: CaptureId, pos: Int): Unit =
+  def exitCapture(t: Thread, id: Ast.CaptureId, pos: Int): Unit =
     match t.captureStack
       case [..xs, top] =>
         val topId ~ startPos = top
@@ -112,7 +112,7 @@ section Engine
         abort "Unexpected empty capture stack"
 
   def isActiveState(nfa: NFA, state: Int): Bool =
-    state == Finish || nfa.getTransitions(state).exists(edge => edge.label is (_: Atom))
+    state == Finish || nfa.getTransitions(state).exists(edge => edge.label is (_: Ast.Atom))
 
   def epsilonClosure(
       nfa: NFA,
@@ -143,7 +143,7 @@ section Engine
         case ExitCapture(name) =>
           exitCapture(t, name, pos)
           Some(edge.to ~ t)
-        case _: Atom =>
+        case _: Ast.Atom =>
           None
 
     while work.size > 0 do
@@ -194,7 +194,7 @@ section Engine
       while iter.hasNext do
         val edge = iter.next()
         match edge.label
-          case a: Atom =>
+          case a: Ast.Atom =>
             if Chars.atomMatches(a, c, dotall, ignoreCase) then
               val t = withPriorityChoice(cloneThread(thread), idx)
               t.step = posAfter

--- a/runtime/native/regex/NFA.jo
+++ b/runtime/native/regex/NFA.jo
@@ -1,7 +1,7 @@
 namespace jo.runtime.native.regex
 
 import jo.runtime.native
-import jo.runtime.native.regex.Ast.*
+import jo.runtime.native.regex.Ast
 
 def Start: Int = 0
 def Finish: Int = 1
@@ -11,8 +11,8 @@ object StartAnchor
 object EndAnchor
 object WordBoundary
 object NotWordBoundary
-class EnterCapture(id: CaptureId)
-class ExitCapture(id: CaptureId)
+class EnterCapture(id: Ast.CaptureId)
+class ExitCapture(id: Ast.CaptureId)
 
 type Label =
     Epsilon
@@ -22,7 +22,7 @@ type Label =
   | NotWordBoundary
   | EnterCapture
   | ExitCapture
-  | Atom
+  | Ast.Atom
 
 class Edge(from: Int, label: Label, to: Int)
 
@@ -49,23 +49,23 @@ class NFA
   def numStates: Int = stateCounter
 end
 
-def construct(pat: Pattern, from: Int, to: Int, nfa: NFA): Unit =
+def construct(pat: Ast.Pattern, from: Int, to: Int, nfa: NFA): Unit =
   match pat
-    case EmptyP =>
+    case Ast.EmptyP =>
       nfa.addTransition(from, Epsilon, to)
 
-    case Capture(id, p) =>
+    case Ast.Capture(id, p) =>
       val enter = nfa.newState()
       val exit = nfa.newState()
       nfa.addTransition(from, EnterCapture(id), enter)
       construct(p, enter, exit, nfa)
       nfa.addTransition(exit, ExitCapture(id), to)
 
-    case Or(lhs, rhs) =>
+    case Ast.Or(lhs, rhs) =>
       construct lhs from to nfa
       construct rhs from to nfa
 
-    case Star(p, greedy) =>
+    case Ast.Star(p, greedy) =>
       if greedy then
         construct(p, from, from, nfa)
         nfa.addTransition(from, Epsilon, to)
@@ -73,7 +73,7 @@ def construct(pat: Pattern, from: Int, to: Int, nfa: NFA): Unit =
         nfa.addTransition(from, Epsilon, to)
         construct(p, from, from, nfa)
 
-    case Optional(p, greedy) =>
+    case Ast.Optional(p, greedy) =>
       if greedy then
         construct(p, from, to, nfa)
         nfa.addTransition(from, Epsilon, to)
@@ -81,23 +81,23 @@ def construct(pat: Pattern, from: Int, to: Int, nfa: NFA): Unit =
         nfa.addTransition(from, Epsilon, to)
         construct(p, from, to, nfa)
 
-    case Seq(p1, p2) =>
+    case Ast.Seq(p1, p2) =>
       val mid = nfa.newState()
       construct p1 from mid nfa
       construct p2 mid to nfa
 
-    case AtomP(a) =>
+    case Ast.AtomP(a) =>
       nfa.addTransition(from, a, to)
 
-    case StartP =>
+    case Ast.StartP =>
       nfa.addTransition(from, StartAnchor, to)
 
-    case EndP =>
+    case Ast.EndP =>
       nfa.addTransition(from, EndAnchor, to)
 
-    case WordBoundaryP =>
+    case Ast.WordBoundaryP =>
       nfa.addTransition(from, WordBoundary, to)
 
-    case NotWordBoundaryP =>
+    case Ast.NotWordBoundaryP =>
       nfa.addTransition(from, NotWordBoundary, to)
   end

--- a/runtime/native/regex/Parser.jo
+++ b/runtime/native/regex/Parser.jo
@@ -1,31 +1,9 @@
 namespace jo.runtime.native.regex
 
 import jo.runtime.native
-import jo.runtime.native.regex.Ast.*
+import jo.runtime.native.regex.Ast
 
 // Parser/AST primitives for regex patterns.
-
-section Ast
-  class CharClass(chars: List[Char], ranges: List[Char ~ Char], negated: Bool)
-  object Dot
-
-  type Atom = Char | Dot | CharClass
-
-  class CaptureId(index: Int, name: Option[String])
-
-  union Pattern =
-      EmptyP
-    | AtomP(a: Atom)
-    | Seq(p1: Pattern, p2: Pattern)
-    | Or(p1: Pattern, p2: Pattern)
-    | Star(p: Pattern, greedy: Bool)
-    | Optional(p: Pattern, greedy: Bool)
-    | Capture(id: CaptureId, p: Pattern)
-    | StartP
-    | EndP
-    | WordBoundaryP
-    | NotWordBoundaryP
-end
 
 class CompileOptions(
     maxPatternSize: Int,
@@ -55,9 +33,9 @@ section Chars
   def isSpace(c: Char): Bool =
     c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == 0x000B.toChar
 
-  def singleton(c: Char): CharClass = CharClass([c], [], false)
+  def singleton(c: Char): Ast.CharClass = Ast.CharClass([c], [], false)
 
-  def charClassMatches(cc: CharClass, c: Char, ignoreCase: Bool): Bool =
+  def charClassMatches(cc: Ast.CharClass, c: Char, ignoreCase: Bool): Bool =
     val target = if ignoreCase then foldAscii(c) else c
     val inChars = cc.chars.exists(x =>
       val x2 = if ignoreCase then foldAscii(x) else x
@@ -74,13 +52,13 @@ section Chars
     val present = inChars || inRanges
     if cc.negated then !present else present
 
-  def atomMatches(a: Atom, c: Char, dotall: Bool, ignoreCase: Bool): Bool =
+  def atomMatches(a: Ast.Atom, c: Char, dotall: Bool, ignoreCase: Bool): Bool =
     match a
       case x: Char =>
         if ignoreCase then foldAscii(x) == foldAscii(c)
         else x == c
-      case Dot => dotall || c != '\n'
-      case cc: CharClass => charClassMatches(cc, c, ignoreCase)
+      case Ast.Dot => dotall || c != '\n'
+      case cc: Ast.CharClass => charClassMatches(cc, c, ignoreCase)
 end
 
 class Scanner(reg: String)
@@ -133,12 +111,12 @@ class Parser(scanner: Scanner, options: CompileOptions)
     else
       scanner.skip()
 
-  def parse(): Pattern =
+  def parse(): Ast.Pattern =
     match parseResult()
-      case p: Pattern => p
+      case p: Ast.Pattern => p
       case err: Error => abort(err.message)
 
-  def parseResult(): Pattern | Error =
+  def parseResult(): Ast.Pattern | Error =
     error = None
     val p = parseAlternation()
     if error is None && scanner.hasMore() then
@@ -147,31 +125,31 @@ class Parser(scanner: Scanner, options: CompileOptions)
       case Some(msg) => new Error(msg)
       case None => p
 
-  def parseAlternation(): Pattern =
+  def parseAlternation(): Ast.Pattern =
     if error is Some(_) then
-      EmptyP
+      Ast.EmptyP
     else
       val left = parseSequence()
       if scanner.hasMore() && scanner.peek() == '|' then
         scanner.skip()
-        Or(left, parseAlternation())
+        Ast.Or(left, parseAlternation())
       else
         left
 
-  def parseSequence(): Pattern =
+  def parseSequence(): Ast.Pattern =
     if error is Some(_) then
-      EmptyP
+      Ast.EmptyP
     else
-      var parts: List[Pattern] = []
+      var parts: List[Ast.Pattern] = []
       while scanner.hasMore() && scanner.peek() != ')' && scanner.peek() != '|' do
         parts = parts + parsePostfix()
 
       if parts.isEmpty then
-        EmptyP
+        Ast.EmptyP
       else
         foldSeq(parts)
 
-  def parsePostfix(): Pattern =
+  def parsePostfix(): Ast.Pattern =
     var atom = parseAtom()
     var cont = true
     while cont && scanner.hasMore() && error is None do
@@ -184,7 +162,7 @@ class Parser(scanner: Scanner, options: CompileOptions)
             false
           else
             true
-        atom = Star(atom, greedy)
+        atom = Ast.Star(atom, greedy)
       else if c == '+' then
         scanner.skip()
         val greedy =
@@ -193,7 +171,7 @@ class Parser(scanner: Scanner, options: CompileOptions)
             false
           else
             true
-        atom = Seq(atom, Star(atom, greedy))
+        atom = Ast.Seq(atom, Ast.Star(atom, greedy))
       else if c == '?' then
         scanner.skip()
         val greedy =
@@ -202,14 +180,14 @@ class Parser(scanner: Scanner, options: CompileOptions)
             false
           else
             true
-        atom = Optional(atom, greedy)
+        atom = Ast.Optional(atom, greedy)
       else if c == '{' then
         atom = parseBounded(atom)
       else
         cont = false
     atom
 
-  def parseBounded(base: Pattern): Pattern =
+  def parseBounded(base: Ast.Pattern): Ast.Pattern =
     parseEat('{')
     val min = parseNumber()
     if !scanner.hasMore() then parseError("Unclosed bounded repetition")
@@ -251,7 +229,7 @@ class Parser(scanner: Scanner, options: CompileOptions)
 
     else
       parseError("Invalid bounded repetition syntax")
-      EmptyP
+      Ast.EmptyP
 
   def parseNumber(): Int =
     if !scanner.hasMore() || !Chars.isDigit(scanner.peek()) then
@@ -264,10 +242,10 @@ class Parser(scanner: Scanner, options: CompileOptions)
         value = value * 10 + (ch.toInt - '0'.toInt)
       value
 
-  def parseAtom(): Pattern =
+  def parseAtom(): Ast.Pattern =
     if !scanner.hasMore() then
       parseError("Unexpected end: expected atom")
-      EmptyP
+      Ast.EmptyP
     else
       val c = scanner.peek()
       if c == '(' then
@@ -291,42 +269,42 @@ class Parser(scanner: Scanner, options: CompileOptions)
               parseError("Duplicate capture group name: " + name)
             captureNames += name
             parseEat('>')
-            val id = CaptureId(nextCaptureIndex(), Some(name))
+            val id = Ast.CaptureId(nextCaptureIndex(), Some(name))
 
             val p = parseAlternation()
             parseEat(')')
-            Capture(id, p)
+            Ast.Capture(id, p)
           else
             parseError("Invalid group syntax: expected : or < after (?")
-            EmptyP
+            Ast.EmptyP
         else
-          val id = CaptureId(nextCaptureIndex(), None)
+          val id = Ast.CaptureId(nextCaptureIndex(), None)
           val p = parseAlternation()
           parseEat(')')
-          Capture(id, p)
+          Ast.Capture(id, p)
       else if c == '[' then
         scanner.skip()
-        AtomP(parseClass())
+        Ast.AtomP(parseClass())
       else if c == '.' then
         scanner.skip()
-        AtomP(Dot)
+        Ast.AtomP(Ast.Dot)
       else if c == '^' then
         scanner.skip()
-        StartP
+        Ast.StartP
       else if c == '$' then
         scanner.skip()
-        EndP
+        Ast.EndP
       else if c == '\\' then
         scanner.skip()
         parseEscapedPattern()
       else if c == ')' || c == '|' || c == '*' || c == '+' || c == '?' || c == '{' || c == '}' then
         parseError("Unexpected token: " + c.toString)
-        EmptyP
+        Ast.EmptyP
       else
         scanner.skip()
-        AtomP(c)
+        Ast.AtomP(c)
 
-  def parseClass(): CharClass =
+  def parseClass(): Ast.CharClass =
     var negated = false
     if scanner.hasMore() && scanner.peek() == '^' then
       scanner.skip()
@@ -356,7 +334,7 @@ class Parser(scanner: Scanner, options: CompileOptions)
     if !scanner.hasMore() then parseError("Unclosed character class")
     if first then parseError("Empty character class")
     parseEat(']')
-    CharClass(chars, ranges, negated)
+    Ast.CharClass(chars, ranges, negated)
 
   def parseClassChar(): Char =
     if !scanner.hasMore() then
@@ -375,42 +353,42 @@ class Parser(scanner: Scanner, options: CompileOptions)
     else
       scanner.next()
 
-  def parseEscape(inClass: Bool): Atom =
+  def parseEscape(inClass: Bool): Ast.Atom =
     if !scanner.hasMore() then
       parseError("Dangling escape")
-      CharClass([], [], false)
+      Ast.CharClass([], [], false)
     else
       val c = scanner.next()
 
       if c == 'd' then
-        CharClass([], ['0' ~ '9'], false)
+        Ast.CharClass([], ['0' ~ '9'], false)
       else if c == 'D' then
-        CharClass([], ['0' ~ '9'], true)
+        Ast.CharClass([], ['0' ~ '9'], true)
       else if c == 's' then
-        CharClass([' ', '\t', '\n', '\r', '\f', 0x000B.toChar], [], false)
+        Ast.CharClass([' ', '\t', '\n', '\r', '\f', 0x000B.toChar], [], false)
       else if c == 'S' then
-        CharClass([' ', '\t', '\n', '\r', '\f', 0x000B.toChar], [], true)
+        Ast.CharClass([' ', '\t', '\n', '\r', '\f', 0x000B.toChar], [], true)
       else if c == 'w' then
-        CharClass(['_'], ['a' ~ 'z', 'A' ~ 'Z', '0' ~ '9'], false)
+        Ast.CharClass(['_'], ['a' ~ 'z', 'A' ~ 'Z', '0' ~ '9'], false)
       else if c == 'W' then
-        CharClass(['_'], ['a' ~ 'z', 'A' ~ 'Z', '0' ~ '9'], true)
+        Ast.CharClass(['_'], ['a' ~ 'z', 'A' ~ 'Z', '0' ~ '9'], true)
       else
         classEscapeChar(c)
 
-  def parseEscapedPattern(): Pattern =
+  def parseEscapedPattern(): Ast.Pattern =
     if !scanner.hasMore() then
       parseError("Dangling escape")
-      EmptyP
+      Ast.EmptyP
     else
       val c = scanner.peek()
       if c == 'b' then
         scanner.skip()
-        WordBoundaryP
+        Ast.WordBoundaryP
       else if c == 'B' then
         scanner.skip()
-        NotWordBoundaryP
+        Ast.NotWordBoundaryP
       else
-        AtomP(parseEscape(false))
+        Ast.AtomP(parseEscape(false))
 
   def classEscapeChar(c: Char): Char =
     if c == 'n' then '\n'
@@ -420,34 +398,34 @@ class Parser(scanner: Scanner, options: CompileOptions)
     else if c == 'v' then 0x000B.toChar
     else c
 
-  def foldSeq(parts: List[Pattern]): Pattern =
+  def foldSeq(parts: List[Ast.Pattern]): Ast.Pattern =
     match parts
       case [x] => x
-      case [x, ..xs] => Seq(x, foldSeq(xs))
+      case [x, ..xs] => Ast.Seq(x, foldSeq(xs))
       case _ => abort "internal: empty sequence"
 
-  def repeatExact(base: Pattern, n: Int): Pattern =
+  def repeatExact(base: Ast.Pattern, n: Int): Ast.Pattern =
     assert(n >= 0, "negative repeat")
     if n == 0 then
-      EmptyP
+      Ast.EmptyP
     else
       var acc = base
       var i = 1
       while i < n do
-        acc = Seq(acc, base)
+        acc = Ast.Seq(acc, base)
         i = i + 1
       acc
 
-  def repeatRange(base: Pattern, min: Int, max: Int, greedy: Bool): Pattern =
+  def repeatRange(base: Ast.Pattern, min: Int, max: Int, greedy: Bool): Ast.Pattern =
     var acc = repeatExact(base, min)
     var i = min
     while i < max do
-      acc = Seq(acc, Optional(base, greedy))
+      acc = Ast.Seq(acc, Ast.Optional(base, greedy))
       i = i + 1
     acc
 
-  def repeatAtLeast(base: Pattern, min: Int, greedy: Bool): Pattern =
+  def repeatAtLeast(base: Ast.Pattern, min: Int, greedy: Bool): Ast.Pattern =
     val prefix = repeatExact(base, min)
-    val tail = Star(base, greedy)
-    if min == 0 then tail else Seq(prefix, tail)
+    val tail = Ast.Star(base, greedy)
+    if min == 0 then tail else Ast.Seq(prefix, tail)
 end

--- a/stack-lang/reporting/Config.scala
+++ b/stack-lang/reporting/Config.scala
@@ -107,6 +107,7 @@ object Config:
   val explicitReturnType: Setting[Boolean] = BooleanSetting("--explicit-return-type",  false, "Require functions to have explicit return type")
   val checkShadowing: Setting[Boolean] = BooleanSetting("--check-shadowing",  false, "Check shadowing of local definitions")
   val explicitThis: Setting[Boolean] = BooleanSetting("--explicit-this",  false, "Method calls and field accesses must be explicit select on `this`")
+  val noStarImport: Setting[Boolean] = BooleanSetting("--no-star-import",  false, "Forbid wildcard imports")
 
   //----------------------------------------------------------------------------
   // output config
@@ -247,6 +248,7 @@ object Config:
     explicitReturnType,
     checkShadowing,
     explicitThis,
+    noStarImport,
     sastDir,
   )
 

--- a/stack-lang/typing/Imports.scala
+++ b/stack-lang/typing/Imports.scala
@@ -7,6 +7,7 @@ import sast.*
 import sast.Symbols.*
 import sast.Types.*
 
+import reporting.Config
 import reporting.Reporter
 
 import scala.collection.mutable
@@ -62,7 +63,7 @@ object Imports:
 
   def doImport
       (qualid: Ast.RefTree, alias: Option[String], importScope: Scope, rootNameTable: NameTable)
-      (using rp: Reporter, so: Source, index: SymbolIndex)
+      (using rp: Reporter, so: Source, index: SymbolIndex, config: Config)
   : List[Symbol] =
 
     val imports = new mutable.ArrayBuffer[Symbol]
@@ -116,6 +117,10 @@ object Imports:
     qualid match
       case Ast.Select(qual, name) =>
         val isStar = name == "*"
+
+        if isStar && Config.noStarImport.value then
+          rp.error("--no-star-import is set for this project, write imports explicitly instead of using `*`", qualid.pos)
+
         if isStar && alias.isDefined then
           rp.error("Cannot rename a wildcard import", qualid.pos)
         else

--- a/stack-lang/typing/Namer.scala
+++ b/stack-lang/typing/Namer.scala
@@ -404,6 +404,7 @@ class Namer(using Config) extends Applications with SelectionTyper:
     def handlePrefix(sym: Symbol, oob: OutOfBand): Word =
       oob.testKey(Scope.PrefixKey) match
         case Some(prefix) =>
+          checkExplicitThis(prefix, sym, id.pos)
           // Normalize SAST
           val qual = Ident(prefix)(id.span.point)
           Select(qual, sym.name)(id.span)
@@ -429,6 +430,10 @@ class Namer(using Config) extends Applications with SelectionTyper:
 
       case _ =>
         tryTermName().adapt
+
+  private def checkExplicitThis(prefix: Symbol, sym: Symbol, pos: SourcePosition)(using Reporter): Unit =
+    if Config.explicitThis.value && sym.isOneOf(Flags.Field | Flags.Method) then
+      Reporter.error(s"--explicit-this is set for this project, write member `${sym.name}` explicitly as `${prefix.name}.${sym.name}`", pos)
 
   def transformSelect(word: Ast.Select)(using defn: Definitions, sc: Scope, rp: Reporter, so: Source, tt: TargetType, tvars: TypeVars, cs: ControlScope): Word =
     val Ast.Select(qual, name) = word
@@ -692,7 +697,9 @@ class Namer(using Config) extends Applications with SelectionTyper:
 
         if sym.isField then
           // Normalize SAST
-          val qual = Ident(oob.getKey(Scope.PrefixKey))(id.span)
+          val prefix = oob.getKey(Scope.PrefixKey)
+          checkExplicitThis(prefix, sym, id.pos)
+          val qual = Ident(prefix)(id.span)
           val lhs2 = Select(qual, sym.name)(lhs.span)
           FieldAssign(lhs2, rhs2)
 

--- a/tests/warn/explicit-this.jo
+++ b/tests/warn/explicit-this.jo
@@ -1,0 +1,33 @@
+// options: --explicit-this
+
+class Counter
+  var value: Int
+
+  def Counter(initial: Int) =
+    this.value = initial
+
+  def set(n: Int): Unit =
+    this.value = n
+
+  def increment(): Unit =
+    value = value + 1
+
+  def read(): Int =
+    value
+
+  def reset(): Unit =
+    set 0
+
+  def explicitOk(): Int =
+    this.set(1)
+    this.value
+
+interface Named
+  def raw(): String
+
+  def decorated(): String =
+    raw()
+
+  def explicitDecorated(): String =
+    this.raw()
+end

--- a/tests/warn/explicit-this.jo.check
+++ b/tests/warn/explicit-this.jo.check
@@ -1,0 +1,26 @@
+---------- Error at tests/warn/explicit-this.jo:13:13 ---------------
+|     value = value + 1
+|             ^^^^^
+|             --explicit-this is set for this project, write member `value` explicitly as `this.value`
+
+---------- Error at tests/warn/explicit-this.jo:13:5 ---------------
+|     value = value + 1
+|     ^^^^^
+|     --explicit-this is set for this project, write member `value` explicitly as `this.value`
+
+---------- Error at tests/warn/explicit-this.jo:16:5 ---------------
+|     value
+|     ^^^^^
+|     --explicit-this is set for this project, write member `value` explicitly as `this.value`
+
+---------- Error at tests/warn/explicit-this.jo:19:5 ---------------
+|     set 0
+|     ^^^
+|     --explicit-this is set for this project, write member `set` explicitly as `this.set`
+
+---------- Error at tests/warn/explicit-this.jo:29:5 ---------------
+|     raw()
+|     ^^^
+|     --explicit-this is set for this project, write member `raw` explicitly as `this.raw`
+
+5 error(s), 0 warning(s)

--- a/tests/warn/no-star-import.jo
+++ b/tests/warn/no-star-import.jo
@@ -1,0 +1,6 @@
+// options: --no-star-import
+
+import jo.mutable.*
+
+def main: Unit =
+  println "no star imports"

--- a/tests/warn/no-star-import.jo.check
+++ b/tests/warn/no-star-import.jo.check
@@ -1,0 +1,6 @@
+---------- Error at tests/warn/no-star-import.jo:3:8 ---------------
+| import jo.mutable.*
+|        ^^^^^^^^^^^^
+|        --no-star-import is set for this project, write imports explicitly instead of using `*`
+
+1 error(s), 0 warning(s)


### PR DESCRIPTION
Consolidate compile options

## Summary

It is widely known that wildcard import is problematic in programming languages. However, forbidding them is too radical.

By introducing `--no-star-import`, users may use it in a specific project and at the time they see fit.

## What has changed

- Document compile options
- Enforce `--explicit-this`
- Add `--no-star-import`

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

No
