### PR TITLE
Fix #51: Synthesized named vararg should widen

### DIFF
--- a/stack-lang/sast/TreeChecker.scala
+++ b/stack-lang/sast/TreeChecker.scala
@@ -161,6 +161,19 @@ class TreeChecker()(using defn: Definitions, rp: Reporter, so: Source) extends T
         if !fun.tpe.isPolyType then
           Reporter.error(s"TypeApply expects polymorphic function type, found = ${fun.tpe.show}", fun.pos)
         else
+          for targ <- targs do
+            targ.tpe match
+              case ref: MemberRef =>
+                Reporter.error(s"Unexpected member ref as type argument, found = ${ref.show}", targ.pos)
+
+              case const: ConstantType =>
+                Reporter.error(s"Unexpected constant type as type argument, found = ${const.show}", targ.pos)
+
+              case ref: StaticRef if ref.symbol.isTerm =>
+                Reporter.error(s"Unexpected term ref as type argument, found = ${ref.show}", targ.pos)
+
+              case _ =>
+
           val procType = fun.tpe.asProcType
           val n = targs.size
           val pre = procType.preTypeParamCount

--- a/stack-lang/typing/Applications.scala
+++ b/stack-lang/typing/Applications.scala
@@ -433,7 +433,7 @@ trait Applications extends DynamicTyper:
     */
   private def wrapNamedArg(name: String, arg: Word)(using defn: Definitions): Word =
     val span = arg.span
-    val fun = Ident(defn.compile_namedArg)(span).appliedToTypes(arg.tpe)
+    val fun = Ident(defn.compile_namedArg)(span).appliedToTypes(arg.tpe.widen)
     Apply(fun, List(StringLit(name)(span), arg), Nil)(span)
 
   /** Handle a call to a vararg function whose vararg element type is Mixed[T].

--- a/tests/custom/harpe/Anthropic.jo
+++ b/tests/custom/harpe/Anthropic.jo
@@ -1,0 +1,14 @@
+namespace harpe
+
+import harpe.Model.Rendered
+
+class Anthropic
+  def ask(rendered: Rendered, model: String, client: py.Dynamic, messages: List[String]) =
+    client.messages.create:
+      model = model
+      max_tokens = 8096
+      system = rendered.system
+      messages = messages
+end
+
+def main = println "anthropic"

--- a/tests/custom/harpe/Model.jo
+++ b/tests/custom/harpe/Model.jo
@@ -1,0 +1,5 @@
+namespace harpe
+
+section Model
+  class Rendered(system: String)
+end

--- a/tests/custom/harpe/expect.check
+++ b/tests/custom/harpe/expect.check
@@ -1,0 +1,1 @@
+anthropic

--- a/tests/custom/harpe/test.sh
+++ b/tests/custom/harpe/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_NAME="$(basename "$DIR")"
+PROJECT_ROOT="$(cd "$DIR/../../.." && pwd)"
+
+echo "Testing $TEST_NAME"
+
+rm -f "$DIR/actual.out" "$DIR/app.py"
+
+echo "  - Compiling with Python backend"
+"$PROJECT_ROOT/bin/jo" compile --python --test-pickling --use-runtime-api python "$DIR/Model.jo" "$DIR/Anthropic.jo" -o "$DIR/app.py"
+python3 "$DIR/app.py" > "$DIR/actual.out" 2>&1
+
+diff "$DIR/actual.out" "$DIR/expect.check" || {
+    echo "[error] Python dynamic dispatch test failed"
+    cat "$DIR/actual.out"
+    exit 1
+}
+
+echo "  ✓ All tests passed for $TEST_NAME"

--- a/tests/pos/vararg-named.jo
+++ b/tests/pos/vararg-named.jo
@@ -1,0 +1,23 @@
+import jo.compile.Named
+import jo.compile.Mixed
+
+class Rendered(message: String)
+
+def foo(args: ..Mixed[String]) =
+  for arg in args do println arg
+
+def bar(args: ..Named[String]) =
+  for arg in args do println arg
+
+def main =
+  val name = "Jo"
+
+  val rendered = Rendered("prompt")
+
+  foo:
+    title = "hello"
+    author = name
+
+  bar:
+    title = "hello"
+    prompt = rendered.message

--- a/tests/pos/vararg-named.jo.check
+++ b/tests/pos/vararg-named.jo.check
@@ -1,0 +1,4 @@
+hello
+Jo
+hello
+prompt


### PR DESCRIPTION
Fix #51: Synthesized named vararg should widen

## What has changed

- Fix bug
- Consolidate invariant check

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

No
