### PR TITLE
Prepare Jo 0.11.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.4] - 2026-07-08
+
+### Added
+
+- `Long.parse` and broader numeric parsing coverage. ([#48])
+- Compile options documentation, including `--explicit-this` and
+  `--no-star-import` usage from the command line and build specs. ([#49])
+- Doom Emacs installation notes for the Jo Emacs mode. ([#45])
+
+### Fixed
+
+- `Float.toInt` now truncates correctly in the JavaScript backend. ([#47])
+- Synthesized named varargs now use the widened argument type as their type
+  argument. ([#52])
+- The data-query-agent and sandbox-agent examples use the correct compilation
+  command. ([#46])
+
+[#45]: https://github.com/typescope/jo/pull/45
+[#46]: https://github.com/typescope/jo/pull/46
+[#47]: https://github.com/typescope/jo/pull/47
+[#48]: https://github.com/typescope/jo/pull/48
+[#49]: https://github.com/typescope/jo/pull/49
+[#52]: https://github.com/typescope/jo/pull/52
+
 ## [0.11.3] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.11.3-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.3)
+  [![Release](https://img.shields.io/badge/release-v0.11.4-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.4)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -3,3 +3,4 @@
 {"version":"0.11.1","url":"https://github.com/typescope/jo/releases/download/v0.11.1/jo-0.11.1.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.1/jo-0.11.1.tar.gz.sha256","date":"2026-06-27"}
 {"version":"0.11.2","url":"https://github.com/typescope/jo/releases/download/v0.11.2/jo-0.11.2.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.2/jo-0.11.2.tar.gz.sha256","date":"2026-06-27"}
 {"version":"0.11.3","url":"https://github.com/typescope/jo/releases/download/v0.11.3/jo-0.11.3.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.3/jo-0.11.3.tar.gz.sha256","date":"2026-07-01"}
+{"version":"0.11.4","url":"https://github.com/typescope/jo/releases/download/v0.11.4/jo-0.11.4.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.4/jo-0.11.4.tar.gz.sha256","date":"2026-07-08"}

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 11, 3)
+  val current: Version = Version(0, 11, 4)


### PR DESCRIPTION
## Summary
- bump Jo version to 0.11.4
- update the README release badge and docs versions feed
- add the 0.11.4 changelog section

## Verification
- bin/jo.dev --version -> 0.11.4
- git diff --check