### PR TITLE
Prepare Jo 0.11.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.5] - 2026-07-10
+
+### Fixed
+
+- Snapshot definition ordering during denotation transforms, fixing lambda
+  erasure cases. ([#54])
+- Context parameter desugaring for overriding methods now respects the target
+  interface signature. ([#55])
+- New-expression parsing in colon-call argument blocks. ([#59])
+
+[#54]: https://github.com/typescope/jo/pull/54
+[#55]: https://github.com/typescope/jo/pull/55
+[#59]: https://github.com/typescope/jo/pull/59
+
 ## [0.11.4] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.11.4-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.4)
+  [![Release](https://img.shields.io/badge/release-v0.11.5-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.11.5)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -4,3 +4,4 @@
 {"version":"0.11.2","url":"https://github.com/typescope/jo/releases/download/v0.11.2/jo-0.11.2.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.2/jo-0.11.2.tar.gz.sha256","date":"2026-06-27"}
 {"version":"0.11.3","url":"https://github.com/typescope/jo/releases/download/v0.11.3/jo-0.11.3.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.3/jo-0.11.3.tar.gz.sha256","date":"2026-07-01"}
 {"version":"0.11.4","url":"https://github.com/typescope/jo/releases/download/v0.11.4/jo-0.11.4.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.4/jo-0.11.4.tar.gz.sha256","date":"2026-07-08"}
+{"version":"0.11.5","url":"https://github.com/typescope/jo/releases/download/v0.11.5/jo-0.11.5.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.5/jo-0.11.5.tar.gz.sha256","date":"2026-07-10"}

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 11, 4)
+  val current: Version = Version(0, 11, 5)


### PR DESCRIPTION
## Summary
- Bump Jo version to 0.11.5
- Update README release badge and versions.jsonl
- Add 0.11.5 changelog notes

## Verification
- bin/jo.dev --version
- git diff --check