### PR TITLE
Fix doc comment before annotations

### DIFF
--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -556,6 +556,22 @@ const app = {
         html += `<div class="doc">${this.renderDoc(item.doc)}</div>`;
       }
 
+      // Fields (class)
+      if (item.fields && item.fields.length > 0) {
+        html += `<h3>Fields</h3>`;
+        html += `<div class="members-list">`;
+        for (const f of item.fields) {
+          html += `
+            <div class="member-item">
+              <span class="kind-badge kind-field">field</span>
+              <code>${f.name}: ${this.renderType(f.type)}</code>
+              ${f.doc ? `<div class="doc">${this.renderDoc(f.doc)}</div>` : ''}
+            </div>
+          `;
+        }
+        html += `</div>`;
+      }
+
       // Methods (class/interface)
       if (item.methods && item.methods.length > 0) {
         html += `<h3>Methods</h3>`;
@@ -624,6 +640,22 @@ const app = {
       // Doc
       if (item.doc) {
         html += `<div class="doc">${this.renderDoc(item.doc)}</div>`;
+      }
+
+      // Fields (class)
+      if (item.fields && item.fields.length > 0) {
+        html += `<h3>Fields</h3>`;
+        html += `<div class="members-list">`;
+        for (const f of item.fields) {
+          html += `
+            <div class="member-item">
+              <span class="kind-badge kind-field">field</span>
+              <code>${f.name}: ${this.renderType(f.type)}</code>
+              ${f.doc ? `<div class="doc">${this.renderDoc(f.doc)}</div>` : ''}
+            </div>
+          `;
+        }
+        html += `</div>`;
       }
 
       // Methods for classes/interfaces without foldable (edge case)

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -391,6 +391,7 @@ h3 {
 .kind-abstract  { background: linear-gradient(135deg, #64748b, #475569); color: #fff; }
 .kind-section   { background: linear-gradient(135deg, #7c3aed, #2563eb); color: #fff; }
 .kind-method    { background: linear-gradient(135deg, #14b8a6, #0891b2); color: #fff; }
+.kind-field     { background: linear-gradient(135deg, #0f766e, #047857); color: #fff; }
 .kind-context   { background: linear-gradient(135deg, #f59e0b, #f97316); color: #fff; }
 .kind-object    { background: linear-gradient(135deg, #f97316, #ef4444); color: #fff; }
 

--- a/stack-lang/doc/JsonEmitter.scala
+++ b/stack-lang/doc/JsonEmitter.scala
@@ -382,7 +382,9 @@ object JsonEmitter:
         fieldFirst = false
         val sym = field.symbol
         val visibility = if sym.isPrivate then "private" else "public"
-        out.print(s"""$indent    { "name": ${jsonString(sym.name)}, "type": ${emitType(field.tpt.tpe)}, "visibility": "$visibility" }""")
+        val docLines = defn.index.docComment(sym)
+        val doc = if docLines.nonEmpty then jsonString(docLines.mkString("\n")) else "null"
+        out.print(s"""$indent    { "name": ${jsonString(sym.name)}, "type": ${emitType(field.tpt.tpe)}, "visibility": "$visibility", "doc": $doc }""")
       out.println()
       out.println(s"""$indent  ],""")
 

--- a/stack-lang/parsing/Scanner.scala
+++ b/stack-lang/parsing/Scanner.scala
@@ -37,6 +37,7 @@ class Scanner(stream: CharStream)(using Reporter, Source):
       case Token.CLASS | Token.INTERFACE | Token.OBJECT | Token.EXTENSION => true
       case Token.PARAM | Token.PATTERN | Token.UNION => true
       case Token.SECTION | Token.AUTO | Token.VIEW => true
+      case Token.AT => true
       case _ => false
 
   /** Collect raw preceding comments (no processing).
@@ -164,7 +165,8 @@ class Scanner(stream: CharStream)(using Reporter, Source):
           token.withInfo(indent, commentsFor(token))
 
         else if isOperatorChar(c) then
-          operator().withInfo(indent, Nil)
+          val token = operator()
+          token.withInfo(indent, commentsFor(token))
 
         else if isSpace(c) then
           next()

--- a/tests/tool-build/doc/jo.steps
+++ b/tests/tool-build/doc/jo.steps
@@ -14,6 +14,27 @@ grep -qF '"title": "Doc Demo"' .build/doc-demo/doc/data.js
 grep -qF 'home page for the doc demo' .build/doc-demo/doc/data.js
 : ''
 
+grep -qF 'Annotated top-level function doc' .build/doc-demo/doc/data.js
+: ''
+
+grep -qF 'Annotated class doc' .build/doc-demo/doc/data.js
+: ''
+
+grep -qF 'Annotated field doc' .build/doc-demo/doc/data.js
+: ''
+
+grep -qF 'Visible in the field list.' .build/doc-demo/doc/data.js
+: ''
+
+grep -qF 'Annotated method doc' .build/doc-demo/doc/data.js
+: ''
+
+grep -qF 'Visible in the method list.' .build/doc-demo/doc/data.js
+: ''
+
+grep -qF 'Fields</h3>' .build/doc-demo/doc/assets/app.js
+: ''
+
 rm -rf .build/doc-demo/doc
 
 jo doc

--- a/tests/tool-build/doc/src/Greeter.jo
+++ b/tests/tool-build/doc/src/Greeter.jo
@@ -1,3 +1,28 @@
 namespace Greeter
 
+import jo.compile.intrinsic
+
 def greet(name: String): String = "Hello, " + name
+
+//[ Annotated top-level function doc
+  ! Kept when an annotation sits before the definition.
+//]
+@intrinsic
+def taggedGreeting(name: String): String = greet(name)
+
+//[ Annotated class doc
+  ! Kept when an annotation sits before the class.
+//]
+@intrinsic
+class Annotated(seed: Int)
+  //[ Annotated field doc
+    ! Visible in the field list.
+  //]
+  @intrinsic
+  val count: Int = seed
+
+  //[ Annotated method doc
+    ! Visible in the method list.
+  //]
+  @intrinsic
+  def describe: String = "count"


### PR DESCRIPTION
Fix #50: Keep doc comment before annotations

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

- [x] Source compatibility: existing code continue to compile
- [x] Library compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Build tool compatibility: old projects continue to build

