### PR TITLE
Fix build tool on source change

### DIFF
--- a/docs/jips/0001-expression-contexts.md
+++ b/docs/jips/0001-expression-contexts.md
@@ -1,6 +1,6 @@
 ---
 author: Fengyun Liu
-status: Draft
+status: Accepted
 created: 2026-07-12
 ---
 

--- a/stack-lang/tool/Runner.scala
+++ b/stack-lang/tool/Runner.scala
@@ -125,9 +125,9 @@ object Runner:
   )(using Logger): Result[Unit] =
     val sentinel = sentinelFile
     val args = buildLibArgs(lib, jo)
-    if requiredOutputs.forall(Files.exists(_)) && isUpToDate(lib.sources, lib.checkLibs, Nil, sentinel, args) then
+    if Files.isDirectory(lib.outDir) && requiredOutputs.forall(Files.exists(_)) && isUpToDate(lib.sources, lib.checkLibs, Nil, sentinel, args) then
       return Result.unit
-    Files.createDirectories(lib.outDir)
+    recreateDir(lib.outDir)
     exec(args) match
       case ok @ Result.Ok(_) =>
         Files.writeString(sentinel, fingerprint(args))
@@ -137,9 +137,9 @@ object Runner:
   private def runApp(app: CompileTask.AppTask, jo: String)(using Logger): Result[Unit] =
     val sentinel = appSentinel(app)
     val args = buildAppArgs(app, jo)
-    if Files.exists(app.outFile) && isUpToDate(app.sources, app.checkLibs, app.linkLibs, sentinel, args) then return Result.unit
+    if Files.exists(app.outFile) && Files.isDirectory(app.sastDir) && isUpToDate(app.sources, app.checkLibs, app.linkLibs, sentinel, args) then return Result.unit
     Files.createDirectories(app.outFile.getParent)
-    Files.createDirectories(app.sastDir)
+    recreateDir(app.sastDir)
     exec(args) match
       case ok @ Result.Ok(_) =>
         Files.writeString(sentinel, fingerprint(args))
@@ -151,6 +151,10 @@ object Runner:
 
   private def dirSentinel(dir: Path): Path =
     dir.resolveSibling(dir.getFileName.toString + ".done")
+
+  private def recreateDir(dir: Path): Unit =
+    if Files.exists(dir) then deleteDir(dir)
+    Files.createDirectories(dir)
 
   private def buildLibArgs(lib: CompileTask.LibTask, jo: String): List[String] =
     val args = ArrayBuffer[String]()

--- a/tests/tool-build/source-removal/jo.steps
+++ b/tests/tool-build/source-removal/jo.steps
@@ -1,0 +1,31 @@
+rm -f src/Old.jo src/New.jo
+
+printf 'namespace SourceRemoval\n\ndef value: Age = 1\n' > src/Old.jo
+
+printf 'namespace SourceRemoval\n\ntype Age = Int\n' > src/Lib.jo
+
+jo test
+: '
+1
+'
+
+test -f .build/source-removal/jo-1.0/sast/SourceRemoval/Old.sast
+: ''
+
+rm src/Old.jo
+rm src/Lib.jo
+
+printf 'namespace SourceRemoval\n\ndef value: Int = 2\n' > src/New.jo
+
+jo test
+: '
+2
+'
+
+test ! -f .build/source-removal/jo-1.0/sast/SourceRemoval/Old.sast
+: ''
+
+test -f .build/source-removal/jo-1.0/sast/SourceRemoval/New.sast
+: ''
+
+rm -f src/New.jo

--- a/tests/tool-build/source-removal/jo.toml
+++ b/tests/tool-build/source-removal/jo.toml
@@ -1,0 +1,8 @@
+jo = "1.0"
+name = "source-removal"
+
+[main]
+target = "python"
+
+[test]
+src = ["tests/"]

--- a/tests/tool-build/source-removal/src/Main.jo
+++ b/tests/tool-build/source-removal/src/Main.jo
@@ -1,0 +1,3 @@
+namespace SourceRemoval
+
+def main = println "source removal"

--- a/tests/tool-build/source-removal/tests/Test.jo
+++ b/tests/tool-build/source-removal/tests/Test.jo
@@ -1,0 +1,3 @@
+namespace SourceRemoval.test
+
+def main = println SourceRemoval.value


### PR DESCRIPTION
Fix #43: Fix build tool on source change

## Summary

Clean up the output directory before re-build to avoid obsolete sast files.

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

- [x] Source compatibility: existing code continue to compile
- [x] Library compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Build tool compatibility: old projects continue to build

