### PR TITLE
Add Bytes  to standard library

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,9 +40,12 @@ git rebase --signoff HEAD~3
 <!-- Does this affect compatibility? If so, describe. -->
 
 - [ ] Source compatibility: existing code continue to compile
-- [ ] Library compatibility
+- [ ] SAST compatibility
   - [ ] forward compatibility: new libraries can be used by old compiler
   - [ ] backward comopatibility: old libraries can be used by new compiler
+- [ ] Standard Library compatibility:
+  - [ ] forward compatibility: new code can work with old stdlib
+  - [ ] backward comopatibility: old code work with the new stdlib
 - [ ] Build tool compatibility: old projects continue to build
 
 ---

--- a/lib/Bytes.jo
+++ b/lib/Bytes.jo
@@ -31,4 +31,7 @@ section Bytes
 
   //[ These bytes as a base64 string. //]
   defer def (repr: Repr) toBase64: String
+
+  //[ Build `size` bytes, where byte `i` is `values(i)`. //]
+  defer def fill(size: Int, values: Int => Byte): Bytes
 end

--- a/lib/Bytes.jo
+++ b/lib/Bytes.jo
@@ -1,0 +1,34 @@
+namespace jo
+
+//[ An immutable sequence of bytes.
+  !
+  ! `Bytes` is an opaque buffer with a backend-defined representation (`Bytes.Repr` —
+  ! Python `bytes`, JavaScript `Uint8Array`, and so on). The representation is never
+  ! visible: a program works through the operators below, so no foreign value leaks
+  ! into Jo code.
+  !
+  !     b.size          // the number of bytes
+  !     b.get(0)        // the first byte, in [0, 255]
+  !     b.slice(0, 4)   // the first four bytes
+  !     b.toBase64      // the bytes as a base64 string
+//]
+type Bytes = Bytes.Repr :+ [Bytes.size, Bytes.get, Bytes.slice, Bytes.toBase64]
+
+section Bytes
+  //[ The backend byte buffer. Abstract here; each backend runtime binds it to its
+    ! native bytes type and links the operators below.
+  //]
+  type Repr
+
+  //[ The number of bytes. //]
+  defer def (repr: Repr) size: Int
+
+  //[ The byte at `index`. //]
+  defer def (repr: Repr) get(index: Int): Byte
+
+  //[ The `length` bytes starting at `offset`. //]
+  defer def (repr: Repr) slice(offset: Int, length: Int): Bytes
+
+  //[ These bytes as a base64 string. //]
+  defer def (repr: Repr) toBase64: String
+end

--- a/lib/Bytes.jo
+++ b/lib/Bytes.jo
@@ -15,9 +15,7 @@ namespace jo
 type Bytes = Bytes.Repr :+ [Bytes.size, Bytes.get, Bytes.slice, Bytes.toBase64]
 
 section Bytes
-  //[ The backend byte buffer. Abstract here; each backend runtime binds it to its
-    ! native bytes type and links the operators below.
-  //]
+  //[ The backend byte buffer //]
   type Repr
 
   //[ The number of bytes. //]
@@ -26,7 +24,7 @@ section Bytes
   //[ The byte at `index`. //]
   defer def (repr: Repr) get(index: Int): Byte
 
-  //[ The `length` bytes starting at `offset`. //]
+  //[ Slice `length` bytes starting at `offset`. //]
   defer def (repr: Repr) slice(offset: Int, length: Int): Bytes
 
   //[ These bytes as a base64 string. //]

--- a/runtime/Interpreter.jo
+++ b/runtime/Interpreter.jo
@@ -15,6 +15,14 @@ private def platformCall3(fn: String, arg1: Any, arg2: Any, arg3: Any): Bottom =
 
 private def abort(s: String): Bottom = platformCall1("abort", s)
 
+// Bytes operations (Bytes.Repr is a JVM byte[])
+private section RefBytes
+  def size(repr: Bytes.Repr): Int = platformCall1("bytesSize", repr)
+  def get(repr: Bytes.Repr, index: Int): Byte = platformCall2("bytesGet", repr, index)
+  def slice(repr: Bytes.Repr, offset: Int, length: Int): Bytes = platformCall3("bytesSlice", repr, offset, length)
+  def toBase64(repr: Bytes.Repr): String = platformCall1("bytesToBase64", repr)
+end
+
 private section RefArray
   def create[T](size: Int): Array[T] =
     platformCall1("createRefArray", size)

--- a/runtime/Interpreter.jo
+++ b/runtime/Interpreter.jo
@@ -16,7 +16,7 @@ private def platformCall3(fn: String, arg1: Any, arg2: Any, arg3: Any): Bottom =
 private def abort(s: String): Bottom = platformCall1("abort", s)
 
 // Bytes operations (Bytes.Repr is a JVM byte[])
-private section RefBytes
+private section RawBytes
   def size(repr: Bytes.Repr): Int = platformCall1("bytesSize", repr)
   def get(repr: Bytes.Repr, index: Int): Byte = platformCall2("bytesGet", repr, index)
   def slice(repr: Bytes.Repr, offset: Int, length: Int): Bytes = platformCall3("bytesSlice", repr, offset, length)

--- a/runtime/Interpreter.jo
+++ b/runtime/Interpreter.jo
@@ -21,6 +21,14 @@ private section RefBytes
   def get(repr: Bytes.Repr, index: Int): Byte = platformCall2("bytesGet", repr, index)
   def slice(repr: Bytes.Repr, offset: Int, length: Int): Bytes = platformCall3("bytesSlice", repr, offset, length)
   def toBase64(repr: Bytes.Repr): String = platformCall1("bytesToBase64", repr)
+
+  def fill(size: Int, values: Int => Byte): Bytes =
+    val b: Bytes = platformCall1("bytesAlloc", size)
+    var i = 0
+    while i < size do
+      platformCall3("bytesSet", b, i, values(i))
+      i = i + 1
+    b
 end
 
 private section RefArray

--- a/runtime/javascript/Runtime.jo
+++ b/runtime/javascript/Runtime.jo
@@ -74,7 +74,7 @@ end
 //
 //------------------------------------------------------------------------------
 
-private section RefBytes
+private section RawBytes
   def size(repr: Bytes.Repr): Int = js.dynamic(repr).length.asInt
 
   def get(repr: Bytes.Repr, index: Int): Byte = js.dynamic(repr)[index].cast[Byte]

--- a/runtime/javascript/Runtime.jo
+++ b/runtime/javascript/Runtime.jo
@@ -70,6 +70,24 @@ end
 
 //------------------------------------------------------------------------------
 //
+// Bytes operations (Bytes.Repr is a Uint8Array)
+//
+//------------------------------------------------------------------------------
+
+private section RefBytes
+  def size(repr: Bytes.Repr): Int = js.dynamic(repr).length.asInt
+
+  def get(repr: Bytes.Repr, index: Int): Byte = js.dynamic(repr)[index].cast[Byte]
+
+  def slice(repr: Bytes.Repr, offset: Int, length: Int): Bytes =
+    js.dynamic(repr).slice(offset, offset + length).cast[Bytes]
+
+  def toBase64(repr: Bytes.Repr): String =
+    js.global.Buffer.from(repr).callDynamic("toString", "base64").asString
+end
+
+//------------------------------------------------------------------------------
+//
 // String support
 //
 

--- a/runtime/javascript/Runtime.jo
+++ b/runtime/javascript/Runtime.jo
@@ -84,6 +84,14 @@ private section RefBytes
 
   def toBase64(repr: Bytes.Repr): String =
     js.global.Buffer.from(repr).callDynamic("toString", "base64").asString
+
+  def fill(size: Int, values: Int => Byte): Bytes =
+    val arr = js.init(js.global.Uint8Array, size)
+    var i = 0
+    while i < size do
+      js.dynamic(arr)[i] = values(i).toInt
+      i = i + 1
+    arr.cast[Bytes]
 end
 
 //------------------------------------------------------------------------------

--- a/runtime/native/Core.jo
+++ b/runtime/native/Core.jo
@@ -631,7 +631,7 @@ private def base64Char(v: Int): Int =
   else if v == 62 then 43             // '+'
   else 47                             // '/'
 
-private section RefBytes
+private section RawBytes
   def size(repr: Bytes.Repr): Int = readInt (addAddr (cast[Addr] repr) 4)
 
   def get(repr: Bytes.Repr, index: Int): Byte =

--- a/runtime/native/Core.jo
+++ b/runtime/native/Core.jo
@@ -620,6 +620,67 @@ private def floatToStr(f: Float): String =
 // The class id (cid) makes it possible to tell an array value from class
 // instances.
 
+// Bytes operations. Bytes.Repr is an Addr to a `[cid: Int(4)][size: Int(4)][bytes...]`
+// block. The leading `cid` word is reserved for layout uniformity with other heap
+// objects (arrays lead with ArrayClassId); the bump allocator never reads it, so it
+// is written as 0 for now. The bytes therefore start at offset 8.
+private def base64Char(v: Int): Int =
+  if v < 26 then 65 + v               // 'A'..'Z'
+  else if v < 52 then 97 + (v - 26)   // 'a'..'z'
+  else if v < 62 then 48 + (v - 52)   // '0'..'9'
+  else if v == 62 then 43             // '+'
+  else 47                             // '/'
+
+private section RefBytes
+  def size(repr: Bytes.Repr): Int = readInt (addAddr (cast[Addr] repr) 4)
+
+  def get(repr: Bytes.Repr, index: Int): Byte =
+    readByte (addAddr (cast[Addr] repr) (index + 8))
+
+  def slice(repr: Bytes.Repr, offset: Int, length: Int): Bytes =
+    val src = cast[Addr] repr
+    val dst = GC.alloc (length + 8)
+    writeInt dst 0                        // reserved cid (unused)
+    writeInt (addAddr dst 4) length
+
+    var i = 0
+    while i < length do
+      writeByte (addAddr dst (i + 8)) (readByte (addAddr src (offset + 8 + i)))
+      i = i + 1
+
+    cast[Bytes] dst
+
+  def toBase64(repr: Bytes.Repr): String =
+    val src = cast[Addr] repr
+    val n = readInt (addAddr src 4)
+    val content = addAddr src 8
+    val outLen = ((n + 2) / 3) * 4
+
+    // Output goes to StringOps.fromByteString, which reads a `[byteSize(4)][content]`
+    // byte string — not a Bytes object — so no cid word here.
+    val outBuf = GC.alloc (outLen + 4)
+    writeInt outBuf outLen
+    val out = addAddr outBuf 4
+
+    var i = 0
+    var o = 0
+    while i < n do
+      val b0 = (readByte (addAddr content i)).toInt & 0xFF
+      val b1 = if i + 1 < n then (readByte (addAddr content (i + 1))).toInt & 0xFF else 0
+      val b2 = if i + 2 < n then (readByte (addAddr content (i + 2))).toInt & 0xFF else 0
+      val triple = (b0 << 16) | (b1 << 8) | b2
+
+      writeByte (addAddr out o)       (base64Char ((triple >> 18) & 0x3F)).toByte
+      writeByte (addAddr out (o + 1)) (base64Char ((triple >> 12) & 0x3F)).toByte
+      writeByte (addAddr out (o + 2)) (if i + 1 < n then base64Char ((triple >> 6) & 0x3F) else 61).toByte
+      writeByte (addAddr out (o + 3)) (if i + 2 < n then base64Char (triple & 0x3F) else 61).toByte
+
+      i = i + 3
+      o = o + 4
+
+    StringOps.fromByteString outBuf
+end
+
 private section RefArray
   @intrinsic
   def ArrayClassId: Int = ...

--- a/runtime/native/Core.jo
+++ b/runtime/native/Core.jo
@@ -679,6 +679,18 @@ private section RefBytes
       o = o + 4
 
     StringOps.fromByteString outBuf
+
+  def fill(size: Int, values: Int => Byte): Bytes =
+    val dst = GC.alloc (size + 8)
+    writeInt dst 0                        // reserved cid (unused)
+    writeInt (addAddr dst 4) size
+
+    var i = 0
+    while i < size do
+      writeByte (addAddr dst (i + 8)) (values(i))
+      i = i + 1
+
+    cast[Bytes] dst
 end
 
 private section RefArray

--- a/runtime/python/Runtime.jo
+++ b/runtime/python/Runtime.jo
@@ -35,6 +35,27 @@ end
 
 private def builtins: BuiltIn = py.module("builtins").cast[BuiltIn]
 
+//------------------------------------------------------------------------------
+//
+// Bytes operations (Bytes.Repr is Python `bytes`)
+//
+//------------------------------------------------------------------------------
+
+private def base64Mod: py.Dynamic = py.module("base64")
+
+private section RefBytes
+  def size(repr: Bytes.Repr): Int = builtins.len(repr)
+
+  def get(repr: Bytes.Repr, index: Int): Byte = py.dynamic(repr)[index].cast[Byte]
+
+  def slice(repr: Bytes.Repr, offset: Int, length: Int): Bytes =
+    val sliceObj = py.module("builtins").callDynamic("slice", offset, offset + length)
+    py.dynamic(repr).callDynamic("__getitem__", sliceObj).cast[Bytes]
+
+  def toBase64(repr: Bytes.Repr): String =
+    base64Mod.callDynamic("b64encode", repr).callDynamic("decode", "ascii").asString
+end
+
 private section RefArray
   def create[T](size: Int): Array[T] =
     val result: py.List = builtins.list()

--- a/runtime/python/Runtime.jo
+++ b/runtime/python/Runtime.jo
@@ -54,6 +54,14 @@ private section RefBytes
 
   def toBase64(repr: Bytes.Repr): String =
     base64Mod.callDynamic("b64encode", repr).callDynamic("decode", "ascii").asString
+
+  def fill(size: Int, values: Int => Byte): Bytes =
+    val ba = py.module("builtins").callDynamic("bytearray", size)
+    var i = 0
+    while i < size do
+      py.dynamic(ba)[i] = values(i).toInt
+      i = i + 1
+    py.module("builtins").callDynamic("bytes", ba).cast[Bytes]
 end
 
 private section RefArray

--- a/runtime/python/Runtime.jo
+++ b/runtime/python/Runtime.jo
@@ -43,7 +43,7 @@ private def builtins: BuiltIn = py.module("builtins").cast[BuiltIn]
 
 private def base64Mod: py.Dynamic = py.module("base64")
 
-private section RefBytes
+private section RawBytes
   def size(repr: Bytes.Repr): Int = builtins.len(repr)
 
   def get(repr: Bytes.Repr, index: Int): Byte = py.dynamic(repr)[index].cast[Byte]

--- a/runtime/ruby/Runtime.jo
+++ b/runtime/ruby/Runtime.jo
@@ -55,6 +55,25 @@ end
 
 //------------------------------------------------------------------------------
 //
+// Bytes operations (Bytes.Repr is a binary String)
+//
+
+private section RefBytes
+  def size(repr: Bytes.Repr): Int = rb.dynamic(repr).bytesize.asInt
+
+  def get(repr: Bytes.Repr, index: Int): Byte =
+    rb.dynamic(repr).callDynamic("getbyte", index).cast[Byte]
+
+  def slice(repr: Bytes.Repr, offset: Int, length: Int): Bytes =
+    rb.dynamic(repr).callDynamic("byteslice", offset, length).cast[Bytes]
+
+  // [str].pack("m0") is strict base64 with no newlines — avoids requiring the base64 gem.
+  def toBase64(repr: Bytes.Repr): String =
+    rbRaw("[]").callDynamic("push", repr).callDynamic("pack", "m0").asString
+end
+
+//------------------------------------------------------------------------------
+//
 // String support
 //
 

--- a/runtime/ruby/Runtime.jo
+++ b/runtime/ruby/Runtime.jo
@@ -70,6 +70,15 @@ private section RefBytes
   // [str].pack("m0") is strict base64 with no newlines — avoids requiring the base64 gem.
   def toBase64(repr: Bytes.Repr): String =
     rbRaw("[]").callDynamic("push", repr).callDynamic("pack", "m0").asString
+
+  // [ints].pack("C*") builds a binary String of those bytes.
+  def fill(size: Int, values: Int => Byte): Bytes =
+    val arr = rbRaw("[]")
+    var i = 0
+    while i < size do
+      arr.callDynamic("push", values(i).toInt)
+      i = i + 1
+    arr.callDynamic("pack", "C*").cast[Bytes]
 end
 
 //------------------------------------------------------------------------------

--- a/runtime/ruby/Runtime.jo
+++ b/runtime/ruby/Runtime.jo
@@ -58,7 +58,7 @@ end
 // Bytes operations (Bytes.Repr is a binary String)
 //
 
-private section RefBytes
+private section RawBytes
   def size(repr: Bytes.Repr): Int = rb.dynamic(repr).bytesize.asInt
 
   def get(repr: Bytes.Repr, index: Int): Byte =

--- a/stack-lang/js/Compiler.scala
+++ b/stack-lang/js/Compiler.scala
@@ -29,6 +29,7 @@ object Compiler:
     "jo.Bytes.get"      -> "jo.js.runtime.RefBytes.get",
     "jo.Bytes.slice"    -> "jo.js.runtime.RefBytes.slice",
     "jo.Bytes.toBase64" -> "jo.js.runtime.RefBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.js.runtime.RefBytes.fill",
 
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.js.runtime.RegexEngine.compilePattern",

--- a/stack-lang/js/Compiler.scala
+++ b/stack-lang/js/Compiler.scala
@@ -25,11 +25,11 @@ object Compiler:
 
     "jo.Array.create" -> "jo.js.runtime.RefArray.create",
 
-    "jo.Bytes.size"     -> "jo.js.runtime.RefBytes.size",
-    "jo.Bytes.get"      -> "jo.js.runtime.RefBytes.get",
-    "jo.Bytes.slice"    -> "jo.js.runtime.RefBytes.slice",
-    "jo.Bytes.toBase64" -> "jo.js.runtime.RefBytes.toBase64",
-    "jo.Bytes.fill"     -> "jo.js.runtime.RefBytes.fill",
+    "jo.Bytes.size"     -> "jo.js.runtime.RawBytes.size",
+    "jo.Bytes.get"      -> "jo.js.runtime.RawBytes.get",
+    "jo.Bytes.slice"    -> "jo.js.runtime.RawBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.js.runtime.RawBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.js.runtime.RawBytes.fill",
 
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.js.runtime.RegexEngine.compilePattern",

--- a/stack-lang/js/Compiler.scala
+++ b/stack-lang/js/Compiler.scala
@@ -25,6 +25,11 @@ object Compiler:
 
     "jo.Array.create" -> "jo.js.runtime.RefArray.create",
 
+    "jo.Bytes.size"     -> "jo.js.runtime.RefBytes.size",
+    "jo.Bytes.get"      -> "jo.js.runtime.RefBytes.get",
+    "jo.Bytes.slice"    -> "jo.js.runtime.RefBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.js.runtime.RefBytes.toBase64",
+
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.js.runtime.RegexEngine.compilePattern",
     "jo.regex.Engine.execPatternAt"  -> "jo.js.runtime.RegexEngine.execPatternAt",

--- a/stack-lang/native/Compiler.scala
+++ b/stack-lang/native/Compiler.scala
@@ -33,11 +33,11 @@ object Compiler:
 
     "jo.Array.create" -> "jo.runtime.native.RefArray.create",
 
-    "jo.Bytes.size"     -> "jo.runtime.native.RefBytes.size",
-    "jo.Bytes.get"      -> "jo.runtime.native.RefBytes.get",
-    "jo.Bytes.slice"    -> "jo.runtime.native.RefBytes.slice",
-    "jo.Bytes.toBase64" -> "jo.runtime.native.RefBytes.toBase64",
-    "jo.Bytes.fill"     -> "jo.runtime.native.RefBytes.fill",
+    "jo.Bytes.size"     -> "jo.runtime.native.RawBytes.size",
+    "jo.Bytes.get"      -> "jo.runtime.native.RawBytes.get",
+    "jo.Bytes.slice"    -> "jo.runtime.native.RawBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.runtime.native.RawBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.runtime.native.RawBytes.fill",
 
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.runtime.native.regex.Regex.compilePattern",

--- a/stack-lang/native/Compiler.scala
+++ b/stack-lang/native/Compiler.scala
@@ -33,6 +33,11 @@ object Compiler:
 
     "jo.Array.create" -> "jo.runtime.native.RefArray.create",
 
+    "jo.Bytes.size"     -> "jo.runtime.native.RefBytes.size",
+    "jo.Bytes.get"      -> "jo.runtime.native.RefBytes.get",
+    "jo.Bytes.slice"    -> "jo.runtime.native.RefBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.runtime.native.RefBytes.toBase64",
+
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.runtime.native.regex.Regex.compilePattern",
     "jo.regex.Engine.execPatternAt"  -> "jo.runtime.native.regex.Regex.execPatternAt",

--- a/stack-lang/native/Compiler.scala
+++ b/stack-lang/native/Compiler.scala
@@ -37,6 +37,7 @@ object Compiler:
     "jo.Bytes.get"      -> "jo.runtime.native.RefBytes.get",
     "jo.Bytes.slice"    -> "jo.runtime.native.RefBytes.slice",
     "jo.Bytes.toBase64" -> "jo.runtime.native.RefBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.runtime.native.RefBytes.fill",
 
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.runtime.native.regex.Regex.compilePattern",

--- a/stack-lang/python/Compiler.scala
+++ b/stack-lang/python/Compiler.scala
@@ -27,11 +27,11 @@ object Compiler:
     "jo.Array.create" -> "jo.py.runtime.RefArray.create",
 
     // Bytes operations
-    "jo.Bytes.size"     -> "jo.py.runtime.RefBytes.size",
-    "jo.Bytes.get"      -> "jo.py.runtime.RefBytes.get",
-    "jo.Bytes.slice"    -> "jo.py.runtime.RefBytes.slice",
-    "jo.Bytes.toBase64" -> "jo.py.runtime.RefBytes.toBase64",
-    "jo.Bytes.fill"     -> "jo.py.runtime.RefBytes.fill",
+    "jo.Bytes.size"     -> "jo.py.runtime.RawBytes.size",
+    "jo.Bytes.get"      -> "jo.py.runtime.RawBytes.get",
+    "jo.Bytes.slice"    -> "jo.py.runtime.RawBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.py.runtime.RawBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.py.runtime.RawBytes.fill",
 
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.py.runtime.RegexEngine.compilePattern",

--- a/stack-lang/python/Compiler.scala
+++ b/stack-lang/python/Compiler.scala
@@ -26,6 +26,12 @@ object Compiler:
 
     "jo.Array.create" -> "jo.py.runtime.RefArray.create",
 
+    // Bytes operations
+    "jo.Bytes.size"     -> "jo.py.runtime.RefBytes.size",
+    "jo.Bytes.get"      -> "jo.py.runtime.RefBytes.get",
+    "jo.Bytes.slice"    -> "jo.py.runtime.RefBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.py.runtime.RefBytes.toBase64",
+
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.py.runtime.RegexEngine.compilePattern",
     "jo.regex.Engine.execPatternAt"  -> "jo.py.runtime.RegexEngine.execPatternAt",

--- a/stack-lang/python/Compiler.scala
+++ b/stack-lang/python/Compiler.scala
@@ -31,6 +31,7 @@ object Compiler:
     "jo.Bytes.get"      -> "jo.py.runtime.RefBytes.get",
     "jo.Bytes.slice"    -> "jo.py.runtime.RefBytes.slice",
     "jo.Bytes.toBase64" -> "jo.py.runtime.RefBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.py.runtime.RefBytes.fill",
 
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.py.runtime.RegexEngine.compilePattern",

--- a/stack-lang/ruby/Compiler.scala
+++ b/stack-lang/ruby/Compiler.scala
@@ -25,11 +25,11 @@ object Compiler:
 
     "jo.Array.create" -> "jo.rb.runtime.RefArray.create",
 
-    "jo.Bytes.size"     -> "jo.rb.runtime.RefBytes.size",
-    "jo.Bytes.get"      -> "jo.rb.runtime.RefBytes.get",
-    "jo.Bytes.slice"    -> "jo.rb.runtime.RefBytes.slice",
-    "jo.Bytes.toBase64" -> "jo.rb.runtime.RefBytes.toBase64",
-    "jo.Bytes.fill"     -> "jo.rb.runtime.RefBytes.fill",
+    "jo.Bytes.size"     -> "jo.rb.runtime.RawBytes.size",
+    "jo.Bytes.get"      -> "jo.rb.runtime.RawBytes.get",
+    "jo.Bytes.slice"    -> "jo.rb.runtime.RawBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.rb.runtime.RawBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.rb.runtime.RawBytes.fill",
 
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.rb.runtime.RegexEngine.compilePattern",

--- a/stack-lang/ruby/Compiler.scala
+++ b/stack-lang/ruby/Compiler.scala
@@ -25,6 +25,11 @@ object Compiler:
 
     "jo.Array.create" -> "jo.rb.runtime.RefArray.create",
 
+    "jo.Bytes.size"     -> "jo.rb.runtime.RefBytes.size",
+    "jo.Bytes.get"      -> "jo.rb.runtime.RefBytes.get",
+    "jo.Bytes.slice"    -> "jo.rb.runtime.RefBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.rb.runtime.RefBytes.toBase64",
+
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.rb.runtime.RegexEngine.compilePattern",
     "jo.regex.Engine.execPatternAt"  -> "jo.rb.runtime.RegexEngine.execPatternAt",

--- a/stack-lang/ruby/Compiler.scala
+++ b/stack-lang/ruby/Compiler.scala
@@ -29,6 +29,7 @@ object Compiler:
     "jo.Bytes.get"      -> "jo.rb.runtime.RefBytes.get",
     "jo.Bytes.slice"    -> "jo.rb.runtime.RefBytes.slice",
     "jo.Bytes.toBase64" -> "jo.rb.runtime.RefBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.rb.runtime.RefBytes.fill",
 
     // Regex engine hooks
     "jo.regex.Engine.compilePattern" -> "jo.rb.runtime.RegexEngine.compilePattern",

--- a/stack-lang/sast/Interpreter.scala
+++ b/stack-lang/sast/Interpreter.scala
@@ -22,6 +22,10 @@ object Interpreter:
   val defaultLinkMappings = Map(
     "jo.abort" -> "jo.runtime.interpreter.abort",
     "jo.Array.create" -> "jo.runtime.interpreter.RefArray.create",
+    "jo.Bytes.size"     -> "jo.runtime.interpreter.RefBytes.size",
+    "jo.Bytes.get"      -> "jo.runtime.interpreter.RefBytes.get",
+    "jo.Bytes.slice"    -> "jo.runtime.interpreter.RefBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.runtime.interpreter.RefBytes.toBase64",
     "jo.regex.Engine.compilePattern" -> "jo.runtime.interpreter.RegexEngine.compilePattern",
     "jo.regex.Engine.execPatternAt"  -> "jo.runtime.interpreter.RegexEngine.execPatternAt",
   )
@@ -200,6 +204,26 @@ object Interpreter:
       "cloneRefArray" -> { (args: List[Value]) =>
         val (arrayVal: ArrayVal) :: Nil = args: @unchecked
         ArrayVal(arrayVal.content.clone()) :: Nil
+      },
+
+      "bytesSize" -> { (args: List[Value]) =>
+        val PlatformVal(bytes: Array[Byte]) :: Nil = args: @unchecked
+        IntVal(bytes.length) :: Nil
+      },
+
+      "bytesGet" -> { (args: List[Value]) =>
+        val PlatformVal(bytes: Array[Byte]) :: IntVal(index) :: Nil = args: @unchecked
+        IntVal(bytes(index) & 0xFF) :: Nil
+      },
+
+      "bytesSlice" -> { (args: List[Value]) =>
+        val PlatformVal(bytes: Array[Byte]) :: IntVal(offset) :: IntVal(length) :: Nil = args: @unchecked
+        PlatformVal(bytes.slice(offset, offset + length)) :: Nil
+      },
+
+      "bytesToBase64" -> { (args: List[Value]) =>
+        val PlatformVal(bytes: Array[Byte]) :: Nil = args: @unchecked
+        StringVal(java.util.Base64.getEncoder.encodeToString(bytes)) :: Nil
       },
 
       "abort" -> { (args: List[Value]) =>

--- a/stack-lang/sast/Interpreter.scala
+++ b/stack-lang/sast/Interpreter.scala
@@ -22,11 +22,11 @@ object Interpreter:
   val defaultLinkMappings = Map(
     "jo.abort" -> "jo.runtime.interpreter.abort",
     "jo.Array.create" -> "jo.runtime.interpreter.RefArray.create",
-    "jo.Bytes.size"     -> "jo.runtime.interpreter.RefBytes.size",
-    "jo.Bytes.get"      -> "jo.runtime.interpreter.RefBytes.get",
-    "jo.Bytes.slice"    -> "jo.runtime.interpreter.RefBytes.slice",
-    "jo.Bytes.toBase64" -> "jo.runtime.interpreter.RefBytes.toBase64",
-    "jo.Bytes.fill"     -> "jo.runtime.interpreter.RefBytes.fill",
+    "jo.Bytes.size"     -> "jo.runtime.interpreter.RawBytes.size",
+    "jo.Bytes.get"      -> "jo.runtime.interpreter.RawBytes.get",
+    "jo.Bytes.slice"    -> "jo.runtime.interpreter.RawBytes.slice",
+    "jo.Bytes.toBase64" -> "jo.runtime.interpreter.RawBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.runtime.interpreter.RawBytes.fill",
     "jo.regex.Engine.compilePattern" -> "jo.runtime.interpreter.RegexEngine.compilePattern",
     "jo.regex.Engine.execPatternAt"  -> "jo.runtime.interpreter.RegexEngine.execPatternAt",
   )

--- a/stack-lang/sast/Interpreter.scala
+++ b/stack-lang/sast/Interpreter.scala
@@ -26,6 +26,7 @@ object Interpreter:
     "jo.Bytes.get"      -> "jo.runtime.interpreter.RefBytes.get",
     "jo.Bytes.slice"    -> "jo.runtime.interpreter.RefBytes.slice",
     "jo.Bytes.toBase64" -> "jo.runtime.interpreter.RefBytes.toBase64",
+    "jo.Bytes.fill"     -> "jo.runtime.interpreter.RefBytes.fill",
     "jo.regex.Engine.compilePattern" -> "jo.runtime.interpreter.RegexEngine.compilePattern",
     "jo.regex.Engine.execPatternAt"  -> "jo.runtime.interpreter.RegexEngine.execPatternAt",
   )
@@ -224,6 +225,17 @@ object Interpreter:
       "bytesToBase64" -> { (args: List[Value]) =>
         val PlatformVal(bytes: Array[Byte]) :: Nil = args: @unchecked
         StringVal(java.util.Base64.getEncoder.encodeToString(bytes)) :: Nil
+      },
+
+      "bytesAlloc" -> { (args: List[Value]) =>
+        val IntVal(size) :: Nil = args: @unchecked
+        PlatformVal(new Array[Byte](size)) :: Nil
+      },
+
+      "bytesSet" -> { (args: List[Value]) =>
+        val PlatformVal(bytes: Array[Byte]) :: IntVal(index) :: IntVal(value) :: Nil = args: @unchecked
+        bytes(index) = value.toByte
+        UnitValue
       },
 
       "abort" -> { (args: List[Value]) =>

--- a/tests/stdlib/bytes/basic.jo
+++ b/tests/stdlib/bytes/basic.jo
@@ -1,0 +1,40 @@
+def main =
+  testFillAndGet()
+  testSlice()
+  testBase64()
+  testEmpty()
+
+// "hello" = [104, 101, 108, 108, 111]
+def byteAt(i: Int): Byte =
+  match i
+  case 0 => 104.toByte
+  case 1 => 101.toByte
+  case 2 => 108.toByte
+  case 3 => 108.toByte
+  case _ => 111.toByte
+
+def testFillAndGet =
+  println "--- bytes.fill / size / get ---"
+  val b = Bytes.fill(5, i => byteAt(i))
+  println b.size
+  println b.get(0).toInt
+  println b.get(4).toInt
+
+def testSlice =
+  println "--- bytes.slice ---"
+  val b = Bytes.fill(5, i => byteAt(i))
+  println (b.slice(1, 3).toBase64)
+  println (b.slice(0, 5).size)
+
+def testBase64 =
+  println "--- bytes.toBase64 ---"
+  val b = Bytes.fill(5, i => byteAt(i))
+  println b.toBase64
+  val p = Bytes.fill(3, i => (i * 64).toByte)
+  println p.toBase64
+
+def testEmpty =
+  println "--- bytes empty ---"
+  val e = Bytes.fill(0, i => 0.toByte)
+  println e.size
+  println e.toBase64

--- a/tests/stdlib/bytes/basic.jo.check
+++ b/tests/stdlib/bytes/basic.jo.check
@@ -1,0 +1,13 @@
+--- bytes.fill / size / get ---
+5
+104
+111
+--- bytes.slice ---
+ZWxs
+5
+--- bytes.toBase64 ---
+aGVsbG8=
+AECA
+--- bytes empty ---
+0
+


### PR DESCRIPTION
Add Bytes to standard library

## Summary

With a Bytes type in standard library, it's easier to define contracts for PDF/Image/Word/etc processors.


## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility: 
  - [ ] ~forward compatibility: new libraries can work with old stdlib~
  - [x] backward comopatibility: old libraries work with the new stdlib
- [x] Build tool compatibility: old projects continue to build

Standard library forward compatibility is broken. We must advance the minor version in next release.