### PR TITLE
Release Jo 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.12.1] - 2026-07-16
+
+### Fixed
+
+- `link = true` source dependencies no longer expose their transitive checking
+  dependencies to the depending module. Those transitive dependencies are still
+  passed as link-time inputs, so linked implementations can use their own
+  dependencies without leaking those names to user code.
+
+### Security
+
+- No new ambient capabilities are introduced. The build tool now preserves the
+  checking boundary for linked dependencies by keeping their implementation
+  dependencies out of the dependent module's check scope.
+
+### Compatibility
+
+- No build-spec changes. Projects that relied on accidentally accessing a
+  transitive dependency through a `link = true` dependency must declare that
+  dependency directly if it is intended to be visible to source code.
+
 ## [0.12.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.12.0-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.12.0)
+  [![Release](https://img.shields.io/badge/release-v0.12.1-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.12.1)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -6,3 +6,4 @@
 {"version":"0.11.4","url":"https://github.com/typescope/jo/releases/download/v0.11.4/jo-0.11.4.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.4/jo-0.11.4.tar.gz.sha256","date":"2026-07-08"}
 {"version":"0.11.5","url":"https://github.com/typescope/jo/releases/download/v0.11.5/jo-0.11.5.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.11.5/jo-0.11.5.tar.gz.sha256","date":"2026-07-10"}
 {"version":"0.12.0","url":"https://github.com/typescope/jo/releases/download/v0.12.0/jo-0.12.0.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.0/jo-0.12.0.tar.gz.sha256","date":"2026-07-16"}
+{"version":"0.12.1","url":"https://github.com/typescope/jo/releases/download/v0.12.1/jo-0.12.1.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.1/jo-0.12.1.tar.gz.sha256","date":"2026-07-16"}

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 12, 0)
+  val current: Version = Version(0, 12, 1)


### PR DESCRIPTION
Release Jo 0.12.1.

Verification:
- `bin/jo.dev --version`
- `./build --fat --release`
- targeted tool tests