### PR TITLE
Fix doc comment

### DIFF
--- a/stack-lang/parsing/Parser.scala
+++ b/stack-lang/parsing/Parser.scala
@@ -127,12 +127,12 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     processed.dropWhile(_.isEmpty).reverse.dropWhile(_.isEmpty).reverse
 
   private def processBlockComment(content: String, columnOffset: Int, span: Span): List[String] =
-    val lines = content.linesIterator.toList
+    val slashCount = content.takeWhile(_ == '/').size
+    val lines = stripBlockCommentClosingDelimiter(content, slashCount).linesIterator.toList
     if lines.isEmpty then return Nil
 
 
     val headLine = lines.head
-    val slashCount = headLine.trim.takeWhile(_ == '/').size
     val paddingCount = slashCount + 2
     val stripColumn = columnOffset + paddingCount
 
@@ -161,6 +161,13 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     // end map
 
     headLine.drop(paddingCount) :: restLines
+
+  private def stripBlockCommentClosingDelimiter(content: String, slashCount: Int): String =
+    val closingDelimiter = "/" * slashCount + "]"
+    if content.endsWith(closingDelimiter) then
+      content.dropRight(closingDelimiter.length).trim
+    else
+      content
 
 
   /** Parse a string starting with StringStart(n)

--- a/tests/tool-build/doc/jo.steps
+++ b/tests/tool-build/doc/jo.steps
@@ -14,6 +14,11 @@ grep -qF '"title": "Doc Demo"' .build/app/doc/data.js
 grep -qF 'home page for the doc demo' .build/app/doc/data.js
 : ''
 
+grep -qF '"doc": "One-line doc comment ends inline."' .build/app/doc/data.js
+: ''
+
+grep -qF '"doc": "Multiline doc comment has a closing delimiter on its final text line.\nMiddle line keeps // inside the text.\nFinal line ends inline."' .build/app/doc/data.js
+: ''
 
 grep -qF 'Annotated top-level function doc' .build/app/doc/data.js
 : ''

--- a/tests/tool-build/doc/src/Greeter.jo
+++ b/tests/tool-build/doc/src/Greeter.jo
@@ -4,6 +4,14 @@ import jo.compile.intrinsic
 
 def greet(name: String): String = "Hello, " + name
 
+//[ One-line doc comment ends inline. //]
+def inlineDocComment: String = "inline"
+
+//[ Multiline doc comment has a closing delimiter on its final text line.
+  ! Middle line keeps // inside the text.
+  ! Final line ends inline. //]
+def multilineSlashDocComment: String = "multiline"
+
 //[ Annotated top-level function doc
   ! Kept when an annotation sits before the definition.
 //]


### PR DESCRIPTION
Fix #66 : Fix doc comment

## Summary

Strip the multiline `//]` in comment.

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

No
