### PR TITLE
Allow default values for class parameters

### DIFF
--- a/docs/language/definitions/function-definitions.md
+++ b/docs/language/definitions/function-definitions.md
@@ -175,7 +175,7 @@ def outer(): Int =
 
 **No vararg default** — a vararg parameter (`..`) cannot have a default value.
 
-**Scope** — Class parameters, pattern parameters, and union branch parameters do not support defaults.
+**Scope** — Defaults are supported on function post parameters, class parameters, and union branch parameters. Pattern parameters do not support defaults.
 
 ## Return Type Inference
 

--- a/docs/language/syntax/syntax-summary.md
+++ b/docs/language/syntax/syntax-summary.md
@@ -284,7 +284,7 @@ private_modifier = "private" ["[" name "]"]
 fun_def = "def" [pre_param_section] ident [tparams] [post_param_section]
           [auto_section] [":" type] [receive_params] ["=" block] ["end"]
 
-class_def = "class" name [tparams] [param_section] {class_member} ["end"]
+class_def = "class" name [tparams] [default_param_section] {class_member} ["end"]
 class_member = qualifier class_member_body | view_decl
 class_member_body = def_def | val_decl
 
@@ -305,7 +305,7 @@ view_decl = "view" type ["=" block]
 val_decl = ("val" | "var") name ":" type ["=" block]
 
 union_def = "union" name [tparams] "=" branch {"|" branch} {qualifier def_def} ["end"]
-branch = name [param_section]
+branch = name [default_param_section]
 
 extension_def = "extension" name [tparams] "for" type {qualifier def_def} ["end"]
 
@@ -316,9 +316,10 @@ type_def = "type" [tparams] ident [tparams] ["=" type]
 tparams = "[" tparam {"," tparam} "]"
 tparam = name
 
-pre_param_section  = "(" [simple_params] ")"
-post_param_section = "(" [post_params] ")"
-param_section      = "(" [simple_params] ")"
+pre_param_section     = "(" [simple_params] ")"
+post_param_section    = "(" [post_params] ")"
+param_section         = "(" [simple_params] ")"
+default_param_section = "(" [post_params] ")"
 
 simple_params = simple_param {"," simple_param}
 simple_param  = name ":" type
@@ -330,6 +331,7 @@ lambda_param  = name [":" type]
 post_params = post_param {"," post_param}
 post_param  = name ":" type ["=" default_value]
 
+(* Defaults are accepted in post parameters, class parameters, and union branch parameters. *)
 default_value = integer | boolean | char | float | string | qualid
 
 auto_section = "(" "auto" auto_params ")"

--- a/stack-lang/parsing/Parser.scala
+++ b/stack-lang/parsing/Parser.scala
@@ -752,7 +752,8 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     val preParamList = preParamSection()
     val id = ident()
     val tparams = typeParams()
-    val postParamList = simpleParamSection()
+    val postParamList =
+      if peek() == Token.LPAREN && peek(1) != Token.AUTO then params() else Nil
 
     eat(Token.COLON)
     val resType = typ()
@@ -801,10 +802,6 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
 
     val paramList = preParamList ++ postParamList
     PatDef(id, tparams, paramList, resType, cases, preParamList.size)(pat.span | bodySpan).withMods(mods)
-
-  def simpleParamSection(): List[Param] =
-    if peek() == Token.LPAREN && peek(1) != Token.AUTO then params() else Nil
-
 
   def postParamSection(): List[Param] =
     if peek() == Token.LPAREN && peek(1) != Token.AUTO then params(acceptDefault = true) else Nil

--- a/stack-lang/parsing/Parser.scala
+++ b/stack-lang/parsing/Parser.scala
@@ -860,7 +860,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
 
     // Parse constructor parameters if present (simplified syntax)
     val classParams =
-      if peek() == Token.LPAREN then params()
+      if peek() == Token.LPAREN then params(acceptDefault = true)
       else Nil
 
     // Parse view declarations and members
@@ -1006,7 +1006,7 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
     // Objects cannot have constructor parameters
     if peek() == Token.LPAREN then
       error("Objects cannot have constructor parameters", peekItem().span.toPos)
-      params() // consume them anyway
+      params(acceptDefault = true) // consume them anyway
 
     // Parse view declarations and methods (no vals allowed)
     val views = mutable.ArrayBuffer[ViewDecl]()
@@ -1128,7 +1128,9 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
 
     def branch(): ClassDef =
       val id = ident()
-      val paramList = simpleParamSection()
+      val paramList =
+        if peek() == Token.LPAREN then params(acceptDefault = true)
+        else Nil
       val endSpan = if paramList.isEmpty then id.span else paramList.last.span
       ClassDef(id, Nil, paramList, Nil, Nil, Nil)(id.span | endSpan)
 

--- a/tests/pos/default-param-class.jo
+++ b/tests/pos/default-param-class.jo
@@ -1,0 +1,25 @@
+// Default parameter values in class parameters flow to the synthesized
+// factory function and constructor method.
+
+def open = true
+
+class Issue(name: String, state: Bool = open)
+
+class Ticket(id: Int, title: String = "untitled", priority: Int = 5)
+
+def main(): Unit =
+  val issueFromFactory = Issue("factory")
+  val issueFromConstructor = new Issue("constructor")
+  val closedIssue = Issue("closed", false)
+
+  println(issueFromFactory.name + ": " + issueFromFactory.state.toString)
+  println(issueFromConstructor.name + ": " + issueFromConstructor.state.toString)
+  println(closedIssue.name + ": " + closedIssue.state.toString)
+
+  val ticket1 = Ticket(1)
+  val ticket2 = new Ticket(2, "typed")
+  val ticket3 = Ticket(3, "urgent", 1)
+
+  println(ticket1.id.toString + ": " + ticket1.title + " #" + ticket1.priority.toString)
+  println(ticket2.id.toString + ": " + ticket2.title + " #" + ticket2.priority.toString)
+  println(ticket3.id.toString + ": " + ticket3.title + " #" + ticket3.priority.toString)

--- a/tests/pos/default-param-class.jo.check
+++ b/tests/pos/default-param-class.jo.check
@@ -1,0 +1,6 @@
+factory: true
+constructor: true
+closed: false
+1: untitled #5
+2: typed #5
+3: urgent #1

--- a/tests/pos/default-param-union.jo
+++ b/tests/pos/default-param-union.jo
@@ -1,0 +1,42 @@
+// Default parameter values in union branch definitions flow to each
+// synthesized branch factory function and constructor method.
+
+def open = true
+def fallbackTitle = "untitled"
+
+union WorkItem =
+  Issue(name: String, state: Bool = open) |
+  Ticket(id: Int, title: String = fallbackTitle, priority: Int = 5) |
+  Closed(reason: String = "done")
+
+def main(): Unit =
+  val issueFromFactory: WorkItem = Issue("factory")
+  val issueFromConstructor: WorkItem = new Issue("constructor")
+  val ticketFromFactory: WorkItem = Ticket(1)
+  val ticketFromConstructor: WorkItem = new Ticket(2, "typed")
+  val closedFromFactory: WorkItem = Closed()
+  val closedFromConstructor: WorkItem = new Closed()
+
+  match issueFromFactory
+    case Issue name state => println(name + ": " + state.toString)
+    case _ => pass
+
+  match issueFromConstructor
+    case Issue name state => println(name + ": " + state.toString)
+    case _ => pass
+
+  match ticketFromFactory
+    case Ticket id title priority => println(id.toString + ": " + title + " #" + priority.toString)
+    case _ => pass
+
+  match ticketFromConstructor
+    case Ticket id title priority => println(id.toString + ": " + title + " #" + priority.toString)
+    case _ => pass
+
+  match closedFromFactory
+    case Closed reason => println(reason)
+    case _ => pass
+
+  match closedFromConstructor
+    case Closed reason => println(reason)
+    case _ => pass

--- a/tests/pos/default-param-union.jo.check
+++ b/tests/pos/default-param-union.jo.check
@@ -1,0 +1,6 @@
+factory: true
+constructor: true
+1: untitled #5
+2: typed #5
+done
+done

--- a/tests/warn/default-param-class-union-conform.jo
+++ b/tests/warn/default-param-class-union-conform.jo
@@ -1,0 +1,7 @@
+// Default value types must conform to class and union branch parameter types.
+
+def textDefault = "text"
+
+class BadClassType(x: Int = "oops")
+
+union BadUnionType = BadBranchType(x: Int = textDefault) | GoodBranchType

--- a/tests/warn/default-param-class-union-conform.jo.check
+++ b/tests/warn/default-param-class-union-conform.jo.check
@@ -1,0 +1,21 @@
+---------- Error at tests/warn/default-param-class-union-conform.jo:5:29 ---------------
+| class BadClassType(x: Int = "oops")
+|                             ^^^^^^
+|                             Default value type String does not conform to parameter type Int
+
+---------- Error at tests/warn/default-param-class-union-conform.jo:7:45 ---------------
+| union BadUnionType = BadBranchType(x: Int = textDefault) | GoodBranchType
+|                                             ^^^^^^^^^^^
+|                                             Default value type String does not conform to parameter type Int
+
+---------- Error at tests/warn/default-param-class-union-conform.jo:5:29 ---------------
+| class BadClassType(x: Int = "oops")
+|                             ^^^^^^
+|                             Default value type String does not conform to parameter type Int
+
+---------- Error at tests/warn/default-param-class-union-conform.jo:7:45 ---------------
+| union BadUnionType = BadBranchType(x: Int = textDefault) | GoodBranchType
+|                                             ^^^^^^^^^^^
+|                                             Default value type String does not conform to parameter type Int
+
+4 error(s), 0 warning(s)

--- a/tests/warn/default-param-class-union-shape.jo
+++ b/tests/warn/default-param-class-union-shape.jo
@@ -1,0 +1,6 @@
+// Non-default parameters after default parameters are errors in class and
+// union branch parameters.
+
+class BadClassShape(x: Int = 1, y: Int)
+
+union BadUnionShape = BadBranchShape(x: Int = 1, y: Int) | GoodBranchShape

--- a/tests/warn/default-param-class-union-shape.jo.check
+++ b/tests/warn/default-param-class-union-shape.jo.check
@@ -1,0 +1,21 @@
+---------- Error at tests/warn/default-param-class-union-shape.jo:4:33 ---------------
+| class BadClassShape(x: Int = 1, y: Int)
+|                                 ^^^^^^
+|                                 Parameter 'y' must have a default value because a preceding parameter has one
+
+---------- Error at tests/warn/default-param-class-union-shape.jo:4:33 ---------------
+| class BadClassShape(x: Int = 1, y: Int)
+|                                 ^^^^^^
+|                                 Parameter 'y' must have a default value because a preceding parameter has one
+
+---------- Error at tests/warn/default-param-class-union-shape.jo:6:50 ---------------
+| union BadUnionShape = BadBranchShape(x: Int = 1, y: Int) | GoodBranchShape
+|                                                  ^^^^^^
+|                                                  Parameter 'y' must have a default value because a preceding parameter has one
+
+---------- Error at tests/warn/default-param-class-union-shape.jo:6:50 ---------------
+| union BadUnionShape = BadBranchShape(x: Int = 1, y: Int) | GoodBranchShape
+|                                                  ^^^^^^
+|                                                  Parameter 'y' must have a default value because a preceding parameter has one
+
+4 error(s), 0 warning(s)

--- a/tests/warn/default-param-class-union.jo
+++ b/tests/warn/default-param-class-union.jo
@@ -1,0 +1,6 @@
+// Default parameter value must be a literal or a qualified identifier
+// in class and union branch parameters.
+
+class BadClassExpr(x: Int = (1 + 2))
+
+union BadUnionExpr = BadBranchExpr(x: Int = (1 + 2)) | GoodBranchExpr

--- a/tests/warn/default-param-class-union.jo.check
+++ b/tests/warn/default-param-class-union.jo.check
@@ -1,0 +1,11 @@
+---------- Error at tests/warn/default-param-class-union.jo:4:29 ---------------
+| class BadClassExpr(x: Int = (1 + 2))
+|                             ^
+|                             Default value must be a literal or a qualified identifier
+
+---------- Error at tests/warn/default-param-class-union.jo:6:45 ---------------
+| union BadUnionExpr = BadBranchExpr(x: Int = (1 + 2)) | GoodBranchExpr
+|                                             ^
+|                                             Default value must be a literal or a qualified identifier
+
+2 error(s), 0 warning(s)


### PR DESCRIPTION
Fix #75: Allow default values for class parameters

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

No

## Compatibility impact

No

