### PR TITLE
Fix sast emission

### DIFF
--- a/stack-lang/phases/FrontEnd.scala
+++ b/stack-lang/phases/FrontEnd.scala
@@ -27,10 +27,6 @@ object FrontEnd:
     locally:
       given Definitions = defnLazy.value
 
-      Config.sastDir.value.foreach: dir =>
-        common.IO.ensureExists(dir)
-        for unit <- nss do pickle.Encoder.store(unit, dir, testPickling = false, verbose = false)
-
       nss |> linkStep(nssDelayed, defaultRuntimePackages, defaultMappings) |> translateStep(arrayOpsSection)
 
   def linkStep

--- a/tests/warn/sast-typing-error.jo
+++ b/tests/warn/sast-typing-error.jo
@@ -1,0 +1,2 @@
+// options: --sast /tmp/jo-sast-typing-error
+def main(): Unit = println [1,2,3].sum()

--- a/tests/warn/sast-typing-error.jo.check
+++ b/tests/warn/sast-typing-error.jo.check
@@ -1,0 +1,6 @@
+---------- Error at tests/warn/sast-typing-error.jo:2:28 ---------------
+| def main(): Unit = println [1,2,3].sum()
+|                            ^^^^^^^
+|                            The prefix does not contain the member sum
+
+1 error(s), 0 warning(s)


### PR DESCRIPTION
Fix #78 : Remove redundant sast emission

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [ ] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

No

<!-- Does this affect compatibility? If so, describe. -->
