### PR TITLE
Release Jo 0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.12.4] - 2026-08-05
+
+### Added
+
+- GitHub templates can be listed and scaffolded from private repositories by
+  using locally configured Git credentials, with SSH as a fallback when HTTPS
+  access fails. ([#89])
+
+### Fixed
+
+- Check-visible dependencies now propagate correctly through source modules and
+  registry packages, while dependencies behind a link-only boundary remain
+  hidden during checking and are still supplied at link time. ([#88])
+
+### Security
+
+- Private-template access reuses Git's existing credential configuration and
+  disables interactive Git and SSH prompts; Jo does not collect or store
+  credentials. ([#89])
+
+### Compatibility
+
+- No build-spec changes are required. Projects affected by missing transitive
+  check libraries now compile with their declared dependency graph, without
+  exposing dependencies across link-only boundaries. ([#88])
+- Public GitHub templates and the ZIP fallback continue to work as before;
+  private repositories require `git` on `PATH` and preconfigured credentials.
+  ([#89])
+
+[#88]: https://github.com/typescope/jo/pull/88
+[#89]: https://github.com/typescope/jo/pull/89
+
 ## [0.12.3] - 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.12.3-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.12.3)
+  [![Release](https://img.shields.io/badge/release-v0.12.4-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.12.4)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -9,3 +9,4 @@
 {"version":"0.12.1","url":"https://github.com/typescope/jo/releases/download/v0.12.1/jo-0.12.1.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.1/jo-0.12.1.tar.gz.sha256","date":"2026-07-16"}
 {"version":"0.12.2","url":"https://github.com/typescope/jo/releases/download/v0.12.2/jo-0.12.2.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.2/jo-0.12.2.tar.gz.sha256","date":"2026-07-25"}
 {"version":"0.12.3","url":"https://github.com/typescope/jo/releases/download/v0.12.3/jo-0.12.3.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.3/jo-0.12.3.tar.gz.sha256","date":"2026-08-03"}
+{"version":"0.12.4","url":"https://github.com/typescope/jo/releases/download/v0.12.4/jo-0.12.4.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.4/jo-0.12.4.tar.gz.sha256","date":"2026-08-05"}

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 12, 3)
+  val current: Version = Version(0, 12, 4)


### PR DESCRIPTION
## Summary

- bump Jo version to 0.12.4
- document dependency propagation and private-template improvements
- update the README release badge and published versions index

## Verification

- git diff --check
- bin/jo.dev --version (0.12.4)