### PR TITLE
Improve docs design

### DIFF
--- a/.github/scripts/fetch-stdlib-docs.sh
+++ b/.github/scripts/fetch-stdlib-docs.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Unpack the published stdlib API docs into docs/public/stdlib/<version>/.
+#
+# Each release may attach a jo-stdlib-docs-<version>.tar.gz asset (see RELEASE.md).
+# Releases cut before that asset existed simply do not have one, so a missing
+# download is not an error: the version is skipped and the archive begins at
+# whichever release first shipped the asset. If no version has docs at all, the
+# directory is left absent and the site drops the Standard Library nav entry.
+
+set -uo pipefail
+
+REPO="${JO_REPO:-typescope/jo}"
+ASSET_BASE="${JO_DOCS_ASSET_BASE:-https://github.com/$REPO/releases/download}"
+VERSIONS_FILE="docs/public/versions.jsonl"
+OUT_DIR="docs/public/stdlib"
+
+if [ ! -f "$VERSIONS_FILE" ]; then
+  echo "no $VERSIONS_FILE — skipping stdlib API docs"
+  exit 0
+fi
+
+rm -rf "$OUT_DIR"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# versions.jsonl is append-only and chronological, so the last entry is newest.
+versions="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$VERSIONS_FILE")"
+published=()
+
+for version in $versions; do
+  url="$ASSET_BASE/v$version/jo-stdlib-docs-$version.tar.gz"
+
+  if ! curl -sSfL "$url" -o "$tmp/docs.tar.gz" 2>/dev/null; then
+    echo "  $version — no stdlib docs asset, skipping"
+    continue
+  fi
+
+  dest="$OUT_DIR/$version"
+  mkdir -p "$dest"
+
+  if ! tar xzf "$tmp/docs.tar.gz" -C "$dest" 2>/dev/null; then
+    echo "  $version — asset is not a readable tarball, skipping"
+    rm -rf "$dest"
+    continue
+  fi
+
+  if [ ! -f "$dest/index.html" ] || [ ! -f "$dest/data.js" ]; then
+    echo "  $version — asset is missing index.html or data.js, skipping"
+    rm -rf "$dest"
+    continue
+  fi
+
+  echo "  $version — published at /stdlib/$version/"
+  published+=("$version")
+done
+
+if [ "${#published[@]}" -eq 0 ]; then
+  echo "no stdlib docs assets found — /stdlib/ will not be published"
+  rm -rf "$OUT_DIR"
+  exit 0
+fi
+
+# Newest first: config.js builds the version dropdown from this, and the bare
+# /stdlib/ URL redirects to the head of the list.
+manifest=""
+for (( i = ${#published[@]} - 1; i >= 0; i-- )); do
+  [ -z "$manifest" ] || manifest="$manifest,"
+  manifest="$manifest\"${published[$i]}\""
+done
+printf '[%s]\n' "$manifest" > "$OUT_DIR/versions.json"
+
+newest="${published[-1]}"
+cat > "$OUT_DIR/index.html" <<EOF
+<!doctype html>
+<meta charset="utf-8">
+<title>Jo Standard Library</title>
+<meta http-equiv="refresh" content="0; url=./$newest/">
+<link rel="canonical" href="./$newest/">
+<p>Redirecting to the <a href="./$newest/">Jo $newest standard library documentation</a>.</p>
+EOF
+
+echo "published ${#published[@]} version(s); /stdlib/ redirects to $newest"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           node-version: 24
 
+      # Served at /stdlib/<version>/ — docs/public is copied to the site root
+      # verbatim. Bundles come from release assets, so releases without one are
+      # skipped rather than failing the build.
+      - name: Fetch published stdlib API docs
+        run: .github/scripts/fetch-stdlib-docs.sh
+
       - name: Install dependencies
         run: npm --prefix docs install
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ demos/*/out
 .cache/
 docs/.vitepress/cache/
 docs/.vitepress/dist/
+docs/public/stdlib/
+stdlib-doc/
+jo-stdlib-docs-*.tar.gz
 node_modules/
 .venv/
 .build/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,6 +50,22 @@ This produces:
 
 - [ ] Tarball and checksum created
 
+The standard library API docs ship as a release asset, which is what
+`jo-lang.org/stdlib/X.Y.Z/` is built from. Generate them with `bin/doc` rather
+than the released compiler: it runs the generator out of the working tree, so
+the bundle uses the current documentation system including any design changes
+made since the last release.
+
+```sh
+bin/doc --no-stdlib $(find lib -name '*.jo') \
+  --title "Jo Standard Library" \
+  --project-version X.Y.Z \
+  --out stdlib-doc
+tar czf jo-stdlib-docs-X.Y.Z.tar.gz -C stdlib-doc .
+```
+
+- [ ] Stdlib docs tarball created
+
 ## 3. Tag the Commit
 
 Tag the merged commit so the tag captures the complete release state.
@@ -71,7 +87,8 @@ self-contained on the release page:
 awk -v v="## [X.Y.Z]" 'index($0, v)==1 {f=1; next} /^## \[/ {f=0} f' \
   CHANGELOG.md > RELEASE_NOTES.md
 
-gh release create vX.Y.Z jo-X.Y.Z.tar.gz jo-X.Y.Z.tar.gz.sha256 \
+gh release create vX.Y.Z \
+  jo-X.Y.Z.tar.gz jo-X.Y.Z.tar.gz.sha256 jo-stdlib-docs-X.Y.Z.tar.gz \
   --repo typescope/jo \
   --title "Jo X.Y.Z" \
   --notes-file RELEASE_NOTES.md
@@ -92,8 +109,10 @@ gh workflow run docs.yml --repo typescope/jo
 - [ ] `curl -sSf https://jo-lang.org/install.sh | sh` installs X.Y.Z
 - [ ] `jo --version` prints X.Y.Z after install
 - [ ] `https://jo-lang.org/versions.jsonl` contains the new entry
+- [ ] `https://jo-lang.org/stdlib/X.Y.Z/` shows the new API docs, and the
+      Standard Library nav menu lists the version
 
 ## 7. Clean Up
 
-- [ ] Remove local `jo-X.Y.Z.tar.gz`, `jo-X.Y.Z.tar.gz.sha256`, and
-      `RELEASE_NOTES.md`
+- [ ] Remove local `jo-X.Y.Z.tar.gz`, `jo-X.Y.Z.tar.gz.sha256`,
+      `jo-stdlib-docs-X.Y.Z.tar.gz`, `stdlib-doc/`, and `RELEASE_NOTES.md`

--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -28,7 +28,6 @@ const app = {
 
     // Render navigation
     this.renderNav();
-    this.setupSidebarResize();
 
     // Setup search
     this.setupSearch();
@@ -56,12 +55,13 @@ const app = {
 
   renderPageIndex(data) {
     const container = document.getElementById('nav-page-index');
-    const sidebar = document.getElementById('sidebar');
     if (!data) {
       container.innerHTML = '';
-      sidebar.classList.remove('has-page-index');
       return;
     }
+
+    const namespaceName = data.fullName || data.name;
+    const heading = `<div class="nav-page-index-header">${namespaceName}</div>`;
 
     const kindOrder = ['section', 'class', 'interface', 'abstract', 'object', 'type', 'pattern', 'function', 'context', 'method'];
     const kindLabel = {
@@ -88,13 +88,12 @@ const app = {
 
     const keys = kindOrder.filter(k => byKind[k] && byKind[k].length > 0);
     if (keys.length === 0) {
-      container.innerHTML = '';
-      sidebar.classList.remove('has-page-index');
+      container.innerHTML = heading;
       return;
     }
 
     let groupId = 0;
-    let html = `<div class="nav-page-index-header">On this page</div>`;
+    let html = heading;
     for (const k of keys) {
       const members = byKind[k];
       const collapsed = members.length > 10;
@@ -113,42 +112,6 @@ const app = {
     }
 
     container.innerHTML = html;
-    sidebar.classList.add('has-page-index');
-  },
-
-  setupSidebarResize() {
-    const sidebar = document.getElementById('sidebar');
-    const header = document.getElementById('sidebar-header');
-    const namespaces = document.getElementById('nav-namespaces');
-    const resizer = document.getElementById('nav-resizer');
-
-    resizer.addEventListener('pointerdown', (event) => {
-      event.preventDefault();
-      resizer.setPointerCapture(event.pointerId);
-      resizer.classList.add('dragging');
-    });
-
-    resizer.addEventListener('pointermove', (event) => {
-      if (!resizer.hasPointerCapture(event.pointerId)) return;
-
-      const availableHeight = sidebar.clientHeight - header.offsetHeight - resizer.offsetHeight;
-      const minSectionHeight = Math.min(100, availableHeight / 3);
-      const namespaceHeight = event.clientY - header.getBoundingClientRect().bottom;
-      const clampedHeight = Math.max(
-        minSectionHeight,
-        Math.min(namespaceHeight, availableHeight - minSectionHeight)
-      );
-      namespaces.style.height = `${clampedHeight}px`;
-    });
-
-    const stopResize = (event) => {
-      if (!resizer.hasPointerCapture(event.pointerId)) return;
-      resizer.releasePointerCapture(event.pointerId);
-      resizer.classList.remove('dragging');
-    };
-
-    resizer.addEventListener('pointerup', stopResize);
-    resizer.addEventListener('pointercancel', stopResize);
   },
 
   toggleNavKind(id) {

--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -505,6 +505,7 @@ const app = {
       const isHidden = content.style.display === 'none';
       content.style.display = isHidden ? 'block' : 'none';
       toggle.textContent = isHidden ? '▼' : '▶';
+      content.closest('.definition')?.classList.toggle('expanded', isHidden);
     }
   },
 
@@ -516,7 +517,7 @@ const app = {
     if (kind === 'section' && item.source) {
       const foldId = this.foldId++;
       const expanded = collapsed ? false : this.tryUnfoldFirst();
-      let html = `<div class="definition section-definition kind-def-section" id="${item.fullName}">`;
+      let html = `<div class="definition section-definition kind-def-section${expanded ? ' expanded' : ''}" id="${item.fullName}">`;
       html += `<div class="definition-header foldable-header" onclick="app.toggleFold(${foldId})">`;
       html += `<span class="fold-toggle" id="fold-toggle-${foldId}">${expanded ? '▼' : '▶'}</span>`;
       html += `<span class="kind-badge kind-${kind}">${kind}</span>`;
@@ -567,6 +568,7 @@ const app = {
     if (isFoldable) {
       const foldId = this.foldId++;
       const expanded = collapsed ? false : this.tryUnfoldFirst();
+      if (expanded) html = html.replace(' class="definition ', ' class="definition expanded ');
       html += `<div class="definition-header foldable-header" onclick="app.toggleFold(${foldId})">`;
       html += `<span class="fold-toggle" id="fold-toggle-${foldId}">${expanded ? '▼' : '▶'}</span>`;
       html += `<span class="kind-badge kind-${kind}">${kind}</span>`;

--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -28,6 +28,7 @@ const app = {
 
     // Render navigation
     this.renderNav();
+    this.setupSidebarResize();
 
     // Setup search
     this.setupSearch();
@@ -55,7 +56,12 @@ const app = {
 
   renderPageIndex(data) {
     const container = document.getElementById('nav-page-index');
-    if (!data) { container.innerHTML = ''; return; }
+    const sidebar = document.getElementById('sidebar');
+    if (!data) {
+      container.innerHTML = '';
+      sidebar.classList.remove('has-page-index');
+      return;
+    }
 
     const kindOrder = ['section', 'class', 'interface', 'abstract', 'object', 'type', 'pattern', 'function', 'context', 'method'];
     const kindLabel = {
@@ -81,7 +87,11 @@ const app = {
     if (data.contexts)  data.contexts.forEach(c => addMember(c, 'context'));
 
     const keys = kindOrder.filter(k => byKind[k] && byKind[k].length > 0);
-    if (keys.length === 0) { container.innerHTML = ''; return; }
+    if (keys.length === 0) {
+      container.innerHTML = '';
+      sidebar.classList.remove('has-page-index');
+      return;
+    }
 
     let groupId = 0;
     let html = `<div class="nav-page-index-header">On this page</div>`;
@@ -103,6 +113,42 @@ const app = {
     }
 
     container.innerHTML = html;
+    sidebar.classList.add('has-page-index');
+  },
+
+  setupSidebarResize() {
+    const sidebar = document.getElementById('sidebar');
+    const header = document.getElementById('sidebar-header');
+    const namespaces = document.getElementById('nav-namespaces');
+    const resizer = document.getElementById('nav-resizer');
+
+    resizer.addEventListener('pointerdown', (event) => {
+      event.preventDefault();
+      resizer.setPointerCapture(event.pointerId);
+      resizer.classList.add('dragging');
+    });
+
+    resizer.addEventListener('pointermove', (event) => {
+      if (!resizer.hasPointerCapture(event.pointerId)) return;
+
+      const availableHeight = sidebar.clientHeight - header.offsetHeight - resizer.offsetHeight;
+      const minSectionHeight = Math.min(100, availableHeight / 3);
+      const namespaceHeight = event.clientY - header.getBoundingClientRect().bottom;
+      const clampedHeight = Math.max(
+        minSectionHeight,
+        Math.min(namespaceHeight, availableHeight - minSectionHeight)
+      );
+      namespaces.style.height = `${clampedHeight}px`;
+    });
+
+    const stopResize = (event) => {
+      if (!resizer.hasPointerCapture(event.pointerId)) return;
+      resizer.releasePointerCapture(event.pointerId);
+      resizer.classList.remove('dragging');
+    };
+
+    resizer.addEventListener('pointerup', stopResize);
+    resizer.addEventListener('pointercancel', stopResize);
   },
 
   toggleNavKind(id) {

--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -430,64 +430,60 @@ const app = {
   renderDefinitions(data) {
     let html = '';
 
-    // Group definitions by name
-    const groups = this.groupByName(data);
+    for (const category of this.groupByCategory(data)) {
+      html += `<section class="definition-category">`;
+      html += `<h2 class="definition-category-title">${category.label}</h2>`;
 
-    for (const [name, items] of groups) {
-      html += `<div class="definition-group">`;
-
-      for (const item of items) {
-        html += this.renderDefinition(item);
+      for (const items of category.groups.values()) {
+        html += `<div class="definition-group">`;
+        for (const item of items) {
+          html += this.renderDefinition(item);
+        }
+        html += `</div>`;
       }
 
-      html += `</div>`;
-    }
-
-    // Render sections with content folded by default
-    if (data.sections && data.sections.length > 0) {
-      for (const sec of data.sections) {
-        const sectionData = JO_DOC_DATA.symbols[sec.fullName] ?? sec;
-
-        const foldId = this.foldId++;
-        const expanded = this.tryUnfoldFirst();
-        const sectionContent = this.renderDefinitions(sectionData);
-
-        html += `
-          <div class="definition section-definition" id="${sec.fullName}">
-            <div class="definition-header foldable-header" onclick="app.toggleFold(${foldId})">
-              <span class="fold-toggle" id="fold-toggle-${foldId}">${expanded ? '▼' : '▶'}</span>
-              <span class="kind-badge kind-section">section</span>
-              <span class="definition-name">${sec.name}</span>
-              ${sectionData.source ? `<span class="source-link">${sectionData.source.file}:${sectionData.source.line}</span>` : ''}
-            </div>
-            <div class="fold-content" id="fold-content-${foldId}"${expanded ? '' : ' style="display: none;"'}>
-              ${sectionData.doc ? `<div class="doc">${this.renderDoc(sectionData.doc)}</div>` : ''}
-              ${sectionContent}
-            </div>
-          </div>
-        `;
-      }
+      html += `</section>`;
     }
 
     return html;
   },
 
-  groupByName(data) {
-    const groups = new Map();
+  groupByCategory(data) {
+    const categoryOrder = ['section', 'class', 'interface', 'abstract', 'object', 'type', 'pattern', 'function', 'context'];
+    const categoryLabels = {
+      section: 'Sections', class: 'Classes', interface: 'Interfaces', abstract: 'Abstract Types',
+      object: 'Objects', type: 'Types', pattern: 'Patterns', function: 'Functions', context: 'Context'
+    };
+    const categories = new Map();
 
     const addItem = (item, kind) => {
+      if (!categories.has(kind)) categories.set(kind, new Map());
+      const groups = categories.get(kind);
       const key = item.name;
       if (!groups.has(key)) groups.set(key, []);
-      groups.get(key).push({ ...item, _kind: kind });
+      const collapsedInList = kind === 'class' || kind === 'section';
+      groups.get(key).push({ ...item, _kind: kind, _collapsed: collapsedInList });
     };
 
+    if (data.sections) {
+      data.sections.forEach(section => {
+        const sectionData = JO_DOC_DATA.symbols[section.fullName] ?? section;
+        addItem(sectionData, 'section');
+      });
+    }
     if (data.types) data.types.forEach(t => addItem(t, t.kind));
     if (data.functions) data.functions.forEach(f => addItem(f, 'function'));
     if (data.patterns) data.patterns.forEach(p => addItem(p, 'pattern'));
     if (data.objects) data.objects.forEach(o => addItem(o, 'object'));
     if (data.contexts) data.contexts.forEach(c => addItem(c, 'context'));
 
-    return new Map([...groups.entries()].sort((a, b) => a[0].localeCompare(b[0])));
+    return categoryOrder
+      .filter(kind => categories.has(kind))
+      .map(kind => ({
+        kind,
+        label: categoryLabels[kind],
+        groups: new Map([...categories.get(kind).entries()].sort((a, b) => a[0].localeCompare(b[0])))
+      }));
   },
 
   firstFoldable: false,

--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -55,10 +55,14 @@ const app = {
 
   renderPageIndex(data) {
     const container = document.getElementById('nav-page-index');
+    const appEl = document.getElementById('app');
     if (!data) {
       container.innerHTML = '';
+      appEl.classList.add('no-page-index');
       return;
     }
+
+    appEl.classList.remove('no-page-index');
 
     const namespaceName = data.fullName || data.name;
     const heading = `<div class="nav-page-index-header">${namespaceName}</div>`;
@@ -112,6 +116,7 @@ const app = {
     }
 
     container.innerHTML = html;
+    this.markActiveLinks();
   },
 
   toggleNavKind(id) {
@@ -271,10 +276,8 @@ const app = {
     const path    = sepIdx >= 0 ? raw.slice(0, sepIdx) : raw;
     const kindFilter = sepIdx >= 0 ? raw.slice(sepIdx + 2) : null;
 
-    // Update active nav link (match on fullName part only)
-    document.querySelectorAll('.nav-link').forEach(link => {
-      link.classList.toggle('active', link.getAttribute('href') === '#/' + path);
-    });
+    this.currentRoute = { raw, path, kindFilter };
+    this.markActiveLinks();
 
     if (!path) {
       this.renderPageIndex(null);
@@ -295,6 +298,23 @@ const app = {
         this.renderNotFound(path);
       }
     }
+  },
+
+  currentRoute: { raw: '', path: '', kindFilter: null },
+
+  // Highlight the nav entries for the current route. Namespace links in the
+  // left nav carry the bare path; page-index links carry a ::kind suffix, and
+  // a path visited without a suffix shows every kind, so all of them match.
+  markActiveLinks() {
+    const { raw, path, kindFilter } = this.currentRoute;
+
+    document.querySelectorAll('.nav-link').forEach(link => {
+      const href = link.getAttribute('href');
+      const active = href === '#/' + path ||
+                     href === '#/' + raw ||
+                     (!kindFilter && path !== '' && href.startsWith('#/' + path + '::'));
+      link.classList.toggle('active', active);
+    });
   },
 
   findNamespacePath(fullName) {

--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -184,11 +184,35 @@ const app = {
       return;
     }
 
-    const queryLower = query.toLowerCase();
-    const results = this.search
-      .filter(item => item.name.toLowerCase().includes(queryLower) ||
-                      item.fullName.toLowerCase().includes(queryLower))
-      .slice(0, 10);
+    const normalizedQuery = query.trim();
+    const queryLower = normalizedQuery.toLowerCase();
+    const ranked = this.search
+      .map((item, index) => {
+        const nameLower = item.name.toLowerCase();
+        const fullNameLower = item.fullName.toLowerCase();
+        let rank;
+
+        if (item.name === normalizedQuery) rank = 0;
+        else if (nameLower === queryLower) rank = 1;
+        else if (item.name.startsWith(normalizedQuery)) rank = 2;
+        else if (nameLower.startsWith(queryLower)) rank = 3;
+        else if (item.fullName.includes(normalizedQuery)) rank = 4;
+        else if (fullNameLower.includes(queryLower)) rank = 5;
+        else return null;
+
+        return { item, rank, index };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.rank - b.rank || a.index - b.index);
+
+    const seen = new Set();
+    const results = [];
+    for (const { item } of ranked) {
+      if (seen.has(item.fullName)) continue;
+      seen.add(item.fullName);
+      results.push(item);
+      if (results.length === 10) break;
+    }
 
     this.renderSearchResults(results);
   },

--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -22,8 +22,10 @@ const app = {
     this.nav = JO_DOC_DATA.nav;
     this.search = JO_DOC_DATA.search;
 
-    // Set title
+    // Set title. The version is optional — generators that don't pass one
+    // (`--project-version`) leave the field out entirely.
     document.getElementById('project-title').textContent = this.meta.title;
+    document.getElementById('project-version').textContent = this.meta.version || 'version unknown';
     document.title = this.meta.title;
 
     // Render navigation

--- a/assets/doc/index.html
+++ b/assets/doc/index.html
@@ -14,7 +14,10 @@
   <button id="sidebar-toggle" onclick="app.toggleSidebar()" title="Toggle sidebar">&#x2630;</button>
   <div id="app" class="sidebar-collapsed">
     <header id="content-header">
-      <a href="#/" id="project-title">Documentation</a>
+      <div id="project-identity">
+        <a href="#/" id="project-title">Documentation</a>
+        <span id="project-version"></span>
+      </div>
       <div id="search-container">
         <svg id="search-icon" viewBox="0 0 24 24" aria-hidden="true">
           <circle cx="11" cy="11" r="6.5"></circle>

--- a/assets/doc/index.html
+++ b/assets/doc/index.html
@@ -12,27 +12,28 @@
 </head>
 <body>
   <button id="sidebar-toggle" onclick="app.toggleSidebar()" title="Toggle sidebar">&#x2630;</button>
-  <div id="app">
-    <aside id="sidebar">
-      <div id="sidebar-header">
-        <a href="#/" id="project-title">Documentation</a>
+  <div id="app" class="sidebar-collapsed">
+    <header id="content-header">
+      <a href="#/" id="project-title">Documentation</a>
+      <div id="search-container">
+        <svg id="search-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="11" cy="11" r="6.5"></circle>
+          <path d="m16 16 4 4"></path>
+        </svg>
+        <input type="search" id="search-input" placeholder="Search all namespaces..." aria-label="Search all namespaces">
+        <div id="search-results"></div>
       </div>
+    </header>
+    <aside id="sidebar">
       <nav id="nav-namespaces"></nav>
-      <div id="nav-resizer"></div>
-      <nav id="nav-page-index"></nav>
     </aside>
     <main id="content">
-      <div id="content-header">
-        <div id="search-container">
-          <input type="text" id="search-input" placeholder="Search symbols...">
-          <div id="search-results"></div>
-        </div>
-      </div>
       <div id="breadcrumb"></div>
       <div id="main-content">
         <p>Loading...</p>
       </div>
     </main>
+    <nav id="nav-page-index"></nav>
   </div>
   <script src="data.js"></script>
   <script src="assets/app.js"></script>

--- a/assets/doc/index.html
+++ b/assets/doc/index.html
@@ -18,6 +18,7 @@
         <a href="#/" id="project-title">Documentation</a>
       </div>
       <nav id="nav-namespaces"></nav>
+      <div id="nav-resizer"></div>
       <nav id="nav-page-index"></nav>
     </aside>
     <main id="content">

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -221,6 +221,11 @@ body::before {
 
 #app.sidebar-collapsed { grid-template-columns: 0 minmax(0, 1fr) 220px; }
 
+/* No page index (home, namespace prefix): collapse the right rail */
+#app.no-page-index #nav-page-index { display: none; }
+#app.no-page-index { grid-template-columns: 220px minmax(0, 1fr) 0; }
+#app.no-page-index.sidebar-collapsed { grid-template-columns: 0 minmax(0, 1fr) 0; }
+
 /* ── Content header (search bar) ─────────────────────────────────────────── */
 #content-header {
   display: grid;
@@ -692,7 +697,9 @@ pre {
   #nav-page-index { display: none; }
 
   #app,
-  #app.sidebar-collapsed {
+  #app.sidebar-collapsed,
+  #app.no-page-index,
+  #app.no-page-index.sidebar-collapsed {
     grid-template-columns: 0 minmax(0, 1fr);
   }
 }

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -494,6 +494,10 @@ h3 {
 .kind-def-object    { border-left-color: #f97316; }
 .kind-def-abstract  { border-left-color: #94a3b8; }
 
+.definition.expanded {
+  border-left-color: var(--border);
+}
+
 .foldable-header {
   cursor: pointer;
   user-select: none;

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -93,6 +93,26 @@ body::before {
   transition: width var(--transition);
 }
 
+#project-identity {
+  grid-column: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+#project-version {
+  flex-shrink: 0;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
 #project-title {
   min-width: 0;
   display: flex;
@@ -692,7 +712,7 @@ pre {
     grid-template-columns: 1fr;
   }
 
-  #project-title { display: none; }
+  #project-identity { display: none; }
   #search-container { grid-column: 1; }
   #nav-page-index { display: none; }
 

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -453,6 +453,21 @@ h3 {
 .kind-object    { background: linear-gradient(135deg, #f97316, #ef4444); color: #fff; }
 
 /* ── Definition cards ────────────────────────────────────────────────────── */
+.definition-category {
+  margin-top: 2rem;
+}
+
+.definition-category-title {
+  margin: 0 0 0.75rem;
+  padding: 0 0 0.45rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border);
+}
+
 .definition {
   margin: 1rem 0;
   padding: 0.9rem 1.1rem 0.9rem 1.1rem;
@@ -469,6 +484,7 @@ h3 {
 
 /* ── Kind-specific accent borders ────────────────────────────────────────── */
 .kind-def-function  { border-left-color: #22c55e; }
+.kind-def-section   { border-left-color: #7c3aed; }
 .kind-def-class     { border-left-color: #3b82f6; }
 .kind-def-interface { border-left-color: #a78bfa; }
 .kind-def-type      { border-left-color: #6366f1; }
@@ -477,22 +493,6 @@ h3 {
 .kind-def-context   { border-left-color: #f59e0b; }
 .kind-def-object    { border-left-color: #f97316; }
 .kind-def-abstract  { border-left-color: #94a3b8; }
-
-.section-definition {
-  margin: 2rem 0 0.5rem;
-  border-top: 2px solid var(--border);
-  padding-top: 0.75rem;
-  border-left: none;
-  background: transparent;
-}
-
-.section-definition > .definition-header {
-  margin-bottom: 0.75rem;
-}
-
-.section-definition .definition {
-  margin-left: 0.75rem;
-}
 
 .foldable-header {
   cursor: pointer;

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -8,6 +8,7 @@
 
   --bg-primary: #ffffff;
   --bg-secondary: #f8fafc;
+  --header-bg: #eef2f7;
   --bg-glass: rgba(255, 255, 255, 0.82);
   --text-primary: #1e293b;
   --text-secondary: #64748b;
@@ -22,12 +23,14 @@
 
   --radius: 10px;
   --transition: 0.2s ease;
+  --header-height: 64px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --bg-primary: #0f172a;
     --bg-secondary: #1e293b;
+    --header-bg: #1a2638;
     --bg-glass: rgba(15, 23, 42, 0.85);
     --text-primary: #f1f5f9;
     --text-secondary: #94a3b8;
@@ -67,34 +70,33 @@ body::before {
 
 /* ── Layout ──────────────────────────────────────────────────────────────── */
 #app {
-  display: flex;
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 220px;
+  grid-template-rows: var(--header-height) minmax(calc(100vh - var(--header-height)), auto);
   min-height: 100vh;
 }
 
 /* ── Sidebar ─────────────────────────────────────────────────────────────── */
 #sidebar {
+  grid-column: 1;
+  grid-row: 2;
   width: 220px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
   position: sticky;
-  top: 0;
-  height: 100vh;
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
   overflow-x: hidden;
   overflow-y: hidden;
   border-right: 1px solid var(--border);
   transition: width var(--transition);
 }
 
-#sidebar-header {
+#project-title {
+  min-width: 0;
   display: flex;
   align-items: center;
-  padding: 0.75rem 0.75rem 0.75rem 2.5rem;
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-}
-
-#project-title {
   font-size: 0.95rem;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -110,7 +112,7 @@ body::before {
 
 #sidebar-toggle {
   position: fixed;
-  top: 0.65rem;
+  top: 0.9rem;
   left: 0.65rem;
   z-index: 300;
   background: none;
@@ -132,45 +134,27 @@ body::before {
   overflow-y: auto;
 }
 
-#sidebar.has-page-index #nav-namespaces {
-  flex: 0 0 auto;
-  height: 45vh;
-}
-
-#nav-resizer {
-  display: none;
-  height: 5px;
-  flex-shrink: 0;
-  cursor: row-resize;
-  border-top: 1px solid var(--border);
-  transition: border-color var(--transition), background var(--transition);
-  touch-action: none;
-}
-
-#sidebar.has-page-index #nav-resizer { display: block; }
-
-#nav-resizer:hover,
-#nav-resizer.dragging {
-  border-color: var(--brand-1);
-  background: var(--brand-soft);
-}
-
 #nav-page-index {
-  padding: 0.75rem 0;
-  flex: 1;
-  min-height: 0;
+  grid-column: 3;
+  grid-row: 2;
+  position: sticky;
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
+  padding: 1.25rem 0.5rem;
   overflow-y: auto;
+  border-left: 1px solid var(--border);
+  background: var(--bg-primary);
 }
-
-#nav-page-index:empty { display: none; }
 
 .nav-page-index-header {
-  padding: 0.4rem 0.75rem 0.3rem;
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-secondary);
+  margin: 0 0.25rem 0.85rem;
+  padding: 0.35rem 0.5rem 0.7rem;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border);
+  overflow-wrap: anywhere;
 }
 
 .nav-kind-group { margin-bottom: 0.5rem; }
@@ -235,45 +219,90 @@ body::before {
   border-right: none;
 }
 
+#app.sidebar-collapsed { grid-template-columns: 0 minmax(0, 1fr) 220px; }
+
 /* ── Content header (search bar) ─────────────────────────────────────────── */
 #content-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 520px) minmax(0, 1fr);
   align-items: center;
-  margin-bottom: 1.75rem;
+  grid-column: 1 / -1;
+  grid-row: 1;
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  width: 100%;
+  height: var(--header-height);
+  padding: 0.75rem 3.25rem;
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
 }
 
 /* ── Search ──────────────────────────────────────────────────────────────── */
 #search-container {
+  grid-column: 2;
   position: relative;
-  flex: 1;
-  max-width: 480px;
+  width: 100%;
+  color: var(--text-secondary);
+}
+
+#search-icon {
+  position: absolute;
+  top: 50%;
+  left: 0.85rem;
+  z-index: 1;
+  width: 1rem;
+  height: 1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  transform: translateY(-50%);
+  pointer-events: none;
+  transition: color var(--transition);
 }
 
 #search-input {
   width: 100%;
-  padding: 0.4rem 0.6rem;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  border-radius: 0;
-  background: transparent;
+  height: 40px;
+  padding: 0 0.95rem 0 2.55rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-primary);
   color: var(--text-primary);
   font-size: 0.9rem;
   font-family: var(--font-sans);
-  transition: border-color var(--transition);
+  line-height: 1;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06), inset 0 1px 1px rgba(15, 23, 42, 0.03);
+  transition: border-color var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+#search-input:hover {
+  border-color: var(--text-secondary);
 }
 
 #search-input:focus {
   outline: none;
-  border-bottom-color: var(--brand-1);
+  border-color: var(--brand-1);
+  background: var(--bg-primary);
+  box-shadow: 0 0 0 3px var(--brand-soft), 0 2px 8px rgba(15, 23, 42, 0.10);
+}
+
+#search-container:focus-within { color: var(--brand-1); }
+
+#search-input::placeholder {
+  color: var(--text-secondary);
+  opacity: 0.8;
 }
 
 #search-results {
   position: absolute;
-  top: calc(100% + 4px);
+  top: calc(100% + 8px);
   left: 0; right: 0;
   background: var(--bg-primary);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-radius: 10px;
   max-height: 400px;
   overflow-y: auto;
   display: none;
@@ -332,12 +361,15 @@ body::before {
 
 /* ── Content area ────────────────────────────────────────────────────────── */
 #content {
+  --content-padding: 2rem;
+  grid-column: 2;
+  grid-row: 2;
   flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 2rem 2rem;
+  padding: 2rem var(--content-padding);
   animation: fadeUp 0.4s ease both;
 }
 
@@ -635,12 +667,28 @@ pre {
 
   #sidebar {
     position: fixed;
-    top: 0;
+    top: var(--header-height);
     left: 0;
-    height: 100vh;
+    height: calc(100vh - var(--header-height));
     z-index: 50;
     background: var(--bg-primary);
   }
 
-  #content { padding: 1.25rem 1rem; }
+  #content {
+    --content-padding: 1rem;
+    padding: 1.25rem var(--content-padding);
+  }
+
+  #content-header {
+    grid-template-columns: 1fr;
+  }
+
+  #project-title { display: none; }
+  #search-container { grid-column: 1; }
+  #nav-page-index { display: none; }
+
+  #app,
+  #app.sidebar-collapsed {
+    grid-template-columns: 0 minmax(0, 1fr);
+  }
 }

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -127,14 +127,39 @@ body::before {
 
 #nav-namespaces {
   padding: 0.5rem 0;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+#sidebar.has-page-index #nav-namespaces {
+  flex: 0 0 auto;
+  height: 45vh;
+}
+
+#nav-resizer {
+  display: none;
+  height: 5px;
   flex-shrink: 0;
+  cursor: row-resize;
+  border-top: 1px solid var(--border);
+  transition: border-color var(--transition), background var(--transition);
+  touch-action: none;
+}
+
+#sidebar.has-page-index #nav-resizer { display: block; }
+
+#nav-resizer:hover,
+#nav-resizer.dragging {
+  border-color: var(--brand-1);
+  background: var(--brand-soft);
 }
 
 #nav-page-index {
   padding: 0.75rem 0;
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  border-top: 1px solid var(--border);
 }
 
 #nav-page-index:empty { display: none; }

--- a/bin/doc
+++ b/bin/doc
@@ -14,8 +14,7 @@ files=(
 
     stack-lang/pickle/*.scala
 
-    stack-lang/phases/Phase.scala
-    stack-lang/phases/EffectCheck.scala
+    stack-lang/phases/*.scala
 
     # doc generator
     stack-lang/doc/*.scala

--- a/ci
+++ b/ci
@@ -204,6 +204,7 @@ background_task() {
     bin/jo compile --reg --report-time tests/pos/fact.jo || error "jo compile --reg"
 
     # check doc
+    bin/doc --no-stdlib $(find lib -name '*.jo') --title "Jo Standard Library" --out libdocs || error "bin/doc"
     bin/jo compile --doc --no-stdlib $(find lib -name '*.jo') --title "Jo Standard Library" --out stdlib-doc || error "doc"
 
     ################################################################################

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -6,6 +6,26 @@ import { fileURLToPath } from 'url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const joGrammar = JSON.parse(readFileSync(resolve(__dirname, '../../tools/vscode/syntaxes/jo.tmLanguage.json'), 'utf-8'))
 
+// Written by .github/scripts/fetch-stdlib-docs.sh, newest version first. Absent
+// on a local build and until a release ships a docs asset, in which case the
+// Standard Library entry is left out rather than linking somewhere that 404s.
+const stdlibVersions = (() => {
+  try {
+    return JSON.parse(readFileSync(resolve(__dirname, '../public/stdlib/versions.json'), 'utf-8'))
+  } catch {
+    return []
+  }
+})()
+
+// Only the newest version is linked — a list of every release would not scale.
+// Older bundles stay published and reachable at /stdlib/<version>/.
+const stdlibNav = stdlibVersions.length === 0 ? [] : [{
+  text: 'Standard Library',
+  // Not a VitePress page, so open it directly instead of via the SPA router.
+  link: `/stdlib/${stdlibVersions[0]}/`,
+  target: '_blank',
+}]
+
 export default defineConfig({
   title: 'Jo Secure Programming Language',
   description: 'Secure programming for the AI era',
@@ -33,6 +53,7 @@ export default defineConfig({
       { text: 'Security', link: '/security/security-problem' },
       { text: 'Build Tool', link: '/usage/install' },
       { text: 'Language Reference', link: '/language/design-principles' },
+      ...stdlibNav,
       { text: 'Blog', link: '/blog/' },
     ],
 

--- a/docs/usage/commands/compile.md
+++ b/docs/usage/commands/compile.md
@@ -49,6 +49,7 @@ Experimental.
 | `--doc` | Generate HTML documentation instead of normal compile output |
 | `--out <dir>` | Documentation output directory |
 | `--title <name>` | Documentation title |
+| `--project-version <version>` | Version shown beside the title. Omitted: the header reads `version unknown` |
 | `--readme <file>` | Markdown file to use as the generated documentation home page |
 | `--include-private` | Include private symbols |
 | `--include-source` | Embed source code in output |

--- a/docs/usage/commands/doc.md
+++ b/docs/usage/commands/doc.md
@@ -32,6 +32,10 @@ include-source = false
 | `include-private` | Include private symbols. Default: `false`.                   |
 | `include-source`  | Embed source locations. Default: `false`.                    |
 
+The documentation header shows the module's version, taken from
+`[module.<id>.package].version`. Modules that declare no package show
+`version unknown`.
+
 The generated documentation is a self-contained directory that can be opened directly in a browser — no web server required.
 
 ## Examples

--- a/stack-lang/doc/Compiler.scala
+++ b/stack-lang/doc/Compiler.scala
@@ -14,12 +14,13 @@ object Compiler:
   // Doc-specific options
   val outputDir: Config.StringSetting = Config.StringSetting("--out", "docs", "output directory")
   val title: Config.StringSetting = Config.StringSetting("--title", "API Documentation", "project title")
+  val projectVersion: Config.StringSetting = Config.StringSetting("--project-version", "", "project version shown in the header")
   val readme: Config.StringSetting = Config.StringSetting("--readme", "", "markdown file to use as home page")
   val includePrivate: Config.BooleanSetting = Config.BooleanSetting("--include-private", false, "include private symbols")
   val includeSource: Config.BooleanSetting = Config.BooleanSetting("--include-source", false, "embed source code")
 
   val docOptions: List[cli.OptionParser.Setting[?]] =
-    outputDir :: title :: readme :: includePrivate :: includeSource :: Config.commonOptions
+    outputDir :: title :: projectVersion :: readme :: includePrivate :: includeSource :: Config.commonOptions
 
   def main(args: Array[String]): Unit =
     given Reporter = Reporter.createReporter()
@@ -34,6 +35,7 @@ object Compiler:
       println("Options:")
       println("  --out <dir>            Output directory (default: docs)")
       println("  --title <name>         Project title for documentation")
+      println("  --project-version <v>  Project version shown in the header")
       println("  --include-private      Include private symbols")
       println("  --include-source       Embed source code in output")
       println()
@@ -77,7 +79,7 @@ object Compiler:
 
     withWriter(outputPath.resolve("data.js")): out =>
       out.print("var JO_DOC_DATA={\"meta\":")
-      JsonEmitter.emitMeta(title.value, out)
+      JsonEmitter.emitMeta(title.value, projectVersion.value, out)
 
       homeMarkdown match
         case Some(md) =>

--- a/stack-lang/doc/JsonEmitter.scala
+++ b/stack-lang/doc/JsonEmitter.scala
@@ -13,10 +13,15 @@ import java.io.PrintWriter
 object JsonEmitter:
 
   /** Emit meta.json - project metadata */
-  def emitMeta(title: String, out: PrintWriter): Unit =
+  def emitMeta(title: String, version: String, out: PrintWriter): Unit =
     val timestamp = java.time.Instant.now().toString
     out.println("{")
     out.println(s"""  "title": ${jsonString(title)},""")
+
+    // Omitted when unset — the viewer falls back to "version unknown"
+    if version.nonEmpty then
+      out.println(s"""  "version": ${jsonString(version)},""")
+
     out.println(s"""  "generatedAt": "$timestamp"""")
     out.println("}")
 

--- a/stack-lang/tool/Build.scala
+++ b/stack-lang/tool/Build.scala
@@ -224,6 +224,7 @@ object Build:
       "--title",
       docSpec.title.getOrElse(module.value),
     )
+    project.pkg(module).foreach(p => options ++= List("--project-version", p.version))
     docSpec.readme.foreach(r => options ++= List("--readme", project.dir.resolve(r).toString))
     if docSpec.includePrivate then options += "--include-private"
     if docSpec.includeSource then options += "--include-source"

--- a/tests/tool-build/doc/jo.steps
+++ b/tests/tool-build/doc/jo.steps
@@ -11,6 +11,9 @@ test -f .build/app/doc/data.js
 grep -qF '"title": "Doc Demo"' .build/app/doc/data.js
 : ''
 
+grep -qF '"version": "0.3.1"' .build/app/doc/data.js
+: ''
+
 grep -qF 'home page for the doc demo' .build/app/doc/data.js
 : ''
 

--- a/tests/tool-build/doc/jo.toml
+++ b/tests/tool-build/doc/jo.toml
@@ -8,3 +8,7 @@ readme = "README.md"
 kind = "app"
 platform = "python"
 src = ["src/"]
+
+[module.app.package]
+name = "doc-demo"
+version = "0.3.1"


### PR DESCRIPTION
Improve docs design

## What has changed

Development testing:

```shell
bin/doc --no-stdlib lib/**/*.jo --out libdocs
```

<img width="1718" height="1303" alt="doc" src="https://github.com/user-attachments/assets/56a4aa41-54a0-4d4f-bd7e-e140264aaf95" />

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->
No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

No