### PR TITLE
Suppport --source-root to not leak absolute path

### DIFF
--- a/docs/usage/commands/compile.md
+++ b/docs/usage/commands/compile.md
@@ -6,15 +6,16 @@ Raw compiler interface. No project spec required.
 
 ```
 # Type-check and emit .sast files
-jo compile [--sast <dir>] <file.jo>... [--lib <dir>]...
+jo compile [--sast <dir>] [--source-root <dir>] <file.jo>... [--lib <dir>]...
 
 # Compile to executable or script
-jo compile --python|--ruby|--js [--sast <dir>] <file.jo>... \
+jo compile --python|--ruby|--js [--sast <dir>] [--source-root <dir>] <file.jo>... \
            [--lib <dir>]... [--link-lib <dir>]... [--link <src>=<tgt>]... -o <output>
 
 # Generate HTML documentation from source files (experimental)
 jo compile --doc [--out <dir>] [--title <name>] [--readme <file>] \
-           [--include-private] [--include-source] <file.jo>...
+           [--include-private] [--include-source] [--source-root <dir>] \
+           <file.jo>...
 
 # Query API information as JSON (experimental)
 jo compile --query <selectors> [<file.jo>...] [--lib <dir>]...
@@ -36,9 +37,20 @@ including stricter checking and compiler-development flags, see
 | Flag                    | Description |
 |-------------------------|-------------|
 | `--sast <dir>`          | Also emit `.sast` files to `<dir>` |
+| `--source-root <dir>`   | Record source paths relative to `<dir>` in generated artifacts |
 | `--lib <dir>`           | Check library directory (can be repeated) |
 | `--use-runtime-api <runtime>` | Make the selected runtime API available as a check library. |
 | `--no-stdlib`           | Disable automatic stdlib loading |
+
+`--source-root` controls source paths published in `.sast` files and generated
+documentation. Sources inside the root are recorded relative to it. For a
+source outside the root, only the filename is recorded, so its containing
+directory is not disclosed. The compiler still uses the original path to read
+the file and report diagnostics.
+
+Project commands such as `jo build` and `jo doc` default the source root to the
+module's project directory. An explicit `--source-root` in the module's
+`compile-options` overrides that default.
 
 ### Documentation
 
@@ -96,6 +108,13 @@ Type-check a library and emit `.sast`:
 
 ```sh
 jo compile --sast .build/api/sast src/API.jo --lib ../core/.build/core/sast
+```
+
+Emit portable `.sast` source paths when invoking the compiler with absolute
+input paths:
+
+```sh
+jo compile --sast .build/api/sast --source-root "$PWD" "$PWD/src/API.jo"
 ```
 
 Type-check a Python runtime library and emit `.sast`:

--- a/stack-lang/cli/Main.scala
+++ b/stack-lang/cli/Main.scala
@@ -319,6 +319,7 @@ object Main:
       |
       |Compile options (library):
       |  --sast <dir>    Compile to .sast files; if no backend flag, this is the only output
+      |  --source-root <dir>  Store source paths relative to this root in generated artifacts
       |  --lib <dir>     Use a precompiled library (can be specified multiple times)
       |  --use-runtime-api <python|ruby|js>
       |                   Make a runtime API available as a check library (js is experimental)

--- a/stack-lang/doc/JsonEmitter.scala
+++ b/stack-lang/doc/JsonEmitter.scala
@@ -6,6 +6,7 @@ import sast.Trees.*
 import sast.Types.*
 import sast.Denotations.*
 import sast.Flags
+import reporting.Config
 
 import scala.collection.mutable
 import java.io.PrintWriter
@@ -200,7 +201,7 @@ object JsonEmitter:
     sections.toList
 
   /** Emit symbols/<fullName>.json for a section */
-  def emitSection(sec: Section, includePrivate: Boolean, out: PrintWriter)(using Definitions): Unit =
+  def emitSection(sec: Section, includePrivate: Boolean, out: PrintWriter)(using Definitions, Config): Unit =
     val sym = sec.symbol
     val defn = summon[Definitions]
 
@@ -214,7 +215,7 @@ object JsonEmitter:
     else
       out.println("""  "doc": null,""")
 
-    out.println(s"""  "source": { "file": ${jsonString(sym.source.file)}, "line": ${sym.sourcePos.startLine + 1} },""")
+    out.println(s"""  "source": { "file": ${jsonString(Config.publishedSourcePath(sym.source.file))}, "line": ${sym.sourcePos.startLine + 1} },""")
 
     // Collect types, functions, patterns, sections, contexts
     val types = mutable.ArrayBuffer[Def]()
@@ -266,7 +267,7 @@ object JsonEmitter:
     out.println("}")
 
   /** Emit members of a namespace (potentially spanning multiple file units) */
-  def emitNamespace(units: List[FileUnit], includePrivate: Boolean, out: PrintWriter)(using Definitions): Unit =
+  def emitNamespace(units: List[FileUnit], includePrivate: Boolean, out: PrintWriter)(using Definitions, Config): Unit =
     val sym = units.head.symbol
     val defn = summon[Definitions]
 
@@ -329,7 +330,7 @@ object JsonEmitter:
 
     out.println("}")
 
-  private def emitTypes(types: List[Def], includePrivate: Boolean, out: PrintWriter, indent: String)(using Definitions): Unit =
+  private def emitTypes(types: List[Def], includePrivate: Boolean, out: PrintWriter, indent: String)(using Definitions, Config): Unit =
     var first = true
 
     for t <- types do
@@ -348,7 +349,7 @@ object JsonEmitter:
 
         case _ => () // Skip other defs that shouldn't be in types list
 
-  private def emitClassDef(cd: ClassDef, includePrivate: Boolean, out: PrintWriter, indent: String)(using Definitions): Unit =
+  private def emitClassDef(cd: ClassDef, includePrivate: Boolean, out: PrintWriter, indent: String)(using Definitions, Config): Unit =
     val sym = cd.symbol
     val defn = summon[Definitions]
 
@@ -376,7 +377,7 @@ object JsonEmitter:
       out.println(s"""$indent  "doc": null,""")
 
     // Source
-    out.println(s"""$indent  "source": { "file": ${jsonString(sym.source.file)}, "line": ${sym.sourcePos.startLine + 1} },""")
+    out.println(s"""$indent  "source": { "file": ${jsonString(Config.publishedSourcePath(sym.source.file))}, "line": ${sym.sourcePos.startLine + 1} },""")
 
     // Fields (for classes)
     if sym.isClass then
@@ -427,7 +428,7 @@ object JsonEmitter:
 
     out.print(s"""$indent}""")
 
-  private def emitInterfaceDef(id: InterfaceDef, includePrivate: Boolean, out: PrintWriter, indent: String)(using Definitions): Unit =
+  private def emitInterfaceDef(id: InterfaceDef, includePrivate: Boolean, out: PrintWriter, indent: String)(using Definitions, Config): Unit =
     val sym = id.symbol
     val defn = summon[Definitions]
 
@@ -450,7 +451,7 @@ object JsonEmitter:
       out.println(s"""$indent  "doc": null,""")
 
     // Source
-    out.println(s"""$indent  "source": { "file": ${jsonString(sym.source.file)}, "line": ${sym.sourcePos.startLine + 1} },""")
+    out.println(s"""$indent  "source": { "file": ${jsonString(Config.publishedSourcePath(sym.source.file))}, "line": ${sym.sourcePos.startLine + 1} },""")
 
     // Methods
     out.println(s"""$indent  "methods": [""")
@@ -465,7 +466,7 @@ object JsonEmitter:
     out.println(s"""$indent  "views": []""")
     out.print(s"""$indent}""")
 
-  private def emitTypeDef(td: TypeDef, out: PrintWriter, indent: String)(using Definitions): Unit =
+  private def emitTypeDef(td: TypeDef, out: PrintWriter, indent: String)(using Definitions, Config): Unit =
     val sym = td.symbol
     val defn = summon[Definitions]
 
@@ -541,7 +542,7 @@ object JsonEmitter:
       out.println(s"""$indent  "doc": null$extras,""")
 
     // Source
-    out.println(s"""$indent  "source": { "file": ${jsonString(sym.source.file)}, "line": ${sym.sourcePos.startLine + 1} }""")
+    out.println(s"""$indent  "source": { "file": ${jsonString(Config.publishedSourcePath(sym.source.file))}, "line": ${sym.sourcePos.startLine + 1} }""")
 
     out.print(s"""$indent}""")
 
@@ -586,7 +587,7 @@ object JsonEmitter:
 
     out.print(s"""$indent}""")
 
-  private def emitFunctions(functions: List[FunDef], out: PrintWriter, indent: String)(using Definitions): Unit =
+  private def emitFunctions(functions: List[FunDef], out: PrintWriter, indent: String)(using Definitions, Config): Unit =
     val defn = summon[Definitions]
     var first = true
 
@@ -642,11 +643,11 @@ object JsonEmitter:
         out.println(s"""$indent  "doc": null,""")
 
       // Source
-      out.println(s"""$indent  "source": { "file": ${jsonString(sym.source.file)}, "line": ${sym.sourcePos.startLine + 1} }""")
+      out.println(s"""$indent  "source": { "file": ${jsonString(Config.publishedSourcePath(sym.source.file))}, "line": ${sym.sourcePos.startLine + 1} }""")
 
       out.print(s"""$indent}""")
 
-  private def emitPatterns(patterns: List[PatDef], out: PrintWriter, indent: String)(using Definitions): Unit =
+  private def emitPatterns(patterns: List[PatDef], out: PrintWriter, indent: String)(using Definitions, Config): Unit =
     val defn = summon[Definitions]
     var first = true
 
@@ -685,11 +686,11 @@ object JsonEmitter:
         out.println(s"""$indent  "doc": null,""")
 
       // Source
-      out.println(s"""$indent  "source": { "file": ${jsonString(sym.source.file)}, "line": ${sym.sourcePos.startLine + 1} }""")
+      out.println(s"""$indent  "source": { "file": ${jsonString(Config.publishedSourcePath(sym.source.file))}, "line": ${sym.sourcePos.startLine + 1} }""")
 
       out.print(s"""$indent}""")
 
-  private def emitContexts(contexts: List[ParamDef], out: PrintWriter, indent: String)(using Definitions): Unit =
+  private def emitContexts(contexts: List[ParamDef], out: PrintWriter, indent: String)(using Definitions, Config): Unit =
     val defn = summon[Definitions]
     var first = true
 
@@ -712,7 +713,7 @@ object JsonEmitter:
         out.println(s"""$indent  "doc": null,""")
 
       // Source
-      out.println(s"""$indent  "source": { "file": ${jsonString(sym.source.file)}, "line": ${sym.sourcePos.startLine + 1} }""")
+      out.println(s"""$indent  "source": { "file": ${jsonString(Config.publishedSourcePath(sym.source.file))}, "line": ${sym.sourcePos.startLine + 1} }""")
 
       out.print(s"""$indent}""")
 

--- a/stack-lang/pickle/Encoder.scala
+++ b/stack-lang/pickle/Encoder.scala
@@ -235,7 +235,7 @@ object Encoder:
 
       val unit2 = Decoder.decode(owner2, nameTable).force()
 
-      val contentBefore = RawPrinter.print(unit).toString
+      val contentBefore = RawPrinter.print(unit, Config.publishedSourcePath(unit.source.file)).toString
       val contentAfter = RawPrinter.print(unit2).toString
 
       if contentBefore != contentAfter then

--- a/stack-lang/pickle/Encoder.scala
+++ b/stack-lang/pickle/Encoder.scala
@@ -8,6 +8,7 @@ import sast.Types.*
 import sast.Symbols.*
 
 import reporting.Reporter
+import reporting.Config
 import common.IO
 
 import scala.collection.mutable
@@ -184,7 +185,7 @@ object Encoder:
       sb ++= "]"
       sb.toString
 
-  private class State(val owner: Symbol, val source: Source):
+  private class State(val owner: Symbol, val source: Source, val publishedSourceFile: String):
     val stringTable = new StringTable
     val nameTable = new NameTable
     val symbolTable = new SymbolTable(source)
@@ -210,7 +211,7 @@ object Encoder:
 
   //----------------------------------------------------------------------------
 
-  def store(unit: FileUnit, outDir: String, testPickling: Boolean, verbose: Boolean = false)(using Definitions, Reporter): Unit =
+  def store(unit: FileUnit, outDir: String, testPickling: Boolean, verbose: Boolean = false)(using Definitions, Reporter, Config): Unit =
     val fileName = IO.fileNameNoExt(unit.source.file) + ".sast"
 
     val targetDir = getTargetDir(unit.owner, outDir)
@@ -248,10 +249,10 @@ object Encoder:
     end if
 
 
-  def encode(unit: FileUnit)(using Definitions): WriteBuffer =
+  def encode(unit: FileUnit)(using Definitions, Config): WriteBuffer =
     val FileUnit(symbol, imports, defs, source) = unit
 
-    given state: State = new State(symbol, source)
+    given state: State = new State(symbol, source, Config.publishedSourcePath(source.file))
     given buf: WriteBuffer = new WriteBuffer(1 << 12)
 
     // Write file header: magic number + version
@@ -1201,7 +1202,7 @@ object Encoder:
 
   /** Encode line lengths as comma-separated hexadecimal */
   private def encodeSource(source: Source)(using WriteBuffer, State): Unit =
-    encodeString(source.file)
+    encodeString(summon[State].publishedSourceFile)
     val lineLengths = source.lineLengths
     repeated(lineLengths) { len => encodeNat(len) }
 

--- a/stack-lang/query/Compiler.scala
+++ b/stack-lang/query/Compiler.scala
@@ -64,7 +64,7 @@ object Compiler:
 
     writeJson(filteredUnits, filter, fields)
 
-  private def writeJson(units: List[FileUnit], filter: Query.Filter, fields: Set[String])(using Reporter, Definitions): Unit =
+  private def writeJson(units: List[FileUnit], filter: Query.Filter, fields: Set[String])(using Reporter, Definitions, Config): Unit =
     val out = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8))
     Query.emitJson(units, filter, fields, false, out)
     out.flush()

--- a/stack-lang/query/Query.scala
+++ b/stack-lang/query/Query.scala
@@ -1,6 +1,6 @@
 package query
 
-import reporting.Reporter
+import reporting.{Config, Reporter}
 import sast.*
 import sast.Symbols.*
 import sast.Trees.*
@@ -19,7 +19,7 @@ object Query:
 
   private val availableFields = outputFields.mkString(",")
 
-  private case class EmitContext(fields: Set[String], out: PrintWriter, indent: String):
+  private case class EmitContext(fields: Set[String], out: PrintWriter, indent: String, publishSourcePath: String => String):
     def indented: EmitContext = copy(indent = indent + "  ")
 
   def parseFields(rawFields: String)(using Reporter): Set[String] =
@@ -135,10 +135,10 @@ object Query:
     fields: Set[String],
     includePrivate: Boolean,
     out: PrintWriter,
-  )(using Reporter, Definitions): Unit =
+  )(using Reporter, Definitions, Config): Unit =
     val trimmedUnits = trimUnits(units, filter, includePrivate)
     val sortedTargets = sortRoots(jsonRoots(trimmedUnits, filter))
-    given EmitContext = EmitContext(fields, out, "  ")
+    given EmitContext = EmitContext(fields, out, "  ", Config.publishedSourcePath)
     out.println("[")
     emitRootList(sortedTargets)
     if sortedTargets.nonEmpty then out.println()
@@ -501,10 +501,10 @@ object Query:
 
   private case class SourceLoc(file: String, line: Int, end: Int)
 
-  private def sourceJson(source: Option[SourceLoc]): String =
+  private def sourceJson(source: Option[SourceLoc])(using ctx: EmitContext): String =
     source match
       case Some(SourceLoc(file, line, end)) =>
-        s"""{ "file": ${JsonUtil.string(file)}, "line": $line, "end": $end }"""
+        s"""{ "file": ${JsonUtil.string(ctx.publishSourcePath(file))}, "line": $line, "end": $end }"""
       case None =>
         "null"
 

--- a/stack-lang/reporting/Config.scala
+++ b/stack-lang/reporting/Config.scala
@@ -6,6 +6,7 @@ import cli.OptionParser.Setting
 import Config.InternalSetting
 
 import scala.collection.mutable
+import java.nio.file.Paths
 
 case class Config(private[Config] rawValues: Map[Setting[?], Any]):
   private val cache: mutable.Map[Setting[?], Any] = mutable.Map.empty
@@ -115,6 +116,28 @@ object Config:
 
   val outFilePath: Setting[Option[String]] = OptionStringSetting("-o", "output file path")
   val sastDir: Setting[Option[String]] = OptionStringSetting("--sast", "sast output directory")
+  val sourceRoot: Setting[Option[String]] = OptionStringSetting(
+    "--source-root",
+    "root used to make source paths portable in generated artifacts",
+  )
+
+  /** The source name persisted in SAST files and exposed in documentation.
+    *
+    * File access continues to use the original path. Absolute files below the
+    * configured root are made relative; files outside it are reduced to their
+    * basename so generated artifacts never disclose their containing directory.
+    */
+  def publishedSourcePath(file: String)(using config: Config): String =
+    val path = Paths.get(file)
+    val absolute = path.toAbsolutePath.normalize()
+    val root = sourceRoot.value
+      .map(Paths.get(_).toAbsolutePath.normalize())
+      .getOrElse(Paths.get("").toAbsolutePath.normalize())
+
+    val published =
+      if absolute.startsWith(root) then root.relativize(absolute)
+      else absolute.getFileName
+    published.toString.replace(java.io.File.separatorChar, '/')
 
 
 
@@ -250,6 +273,7 @@ object Config:
     explicitThis,
     noStarImport,
     sastDir,
+    sourceRoot,
   )
 
   val appOptions = outFilePath :: linkLibPaths :: linkMap :: commonOptions

--- a/stack-lang/sast/RawPrinter.scala
+++ b/stack-lang/sast/RawPrinter.scala
@@ -98,6 +98,15 @@ object RawPrinter:
   //----------------------------------------------------------------------------
 
   def print(unit: FileUnit)(using Definitions): Text =
+    print(unit, unit.source.file)
+
+  /** Print a unit with an explicit serialized source name.
+    *
+    * The source object remains unchanged so spans and line information still
+    * refer to the physical input file. This overload is used by the pickling
+    * round-trip test when artifact path mapping intentionally changes the name.
+    */
+  def print(unit: FileUnit, sourceFile: String)(using Definitions): Text =
     val FileUnit(owner, imports, defs, source) = unit
 
     given state: State = new State(owner)
@@ -111,7 +120,7 @@ object RawPrinter:
         defs.map(printDef).join(LINE_SEP)
       ~ "]"
 
-    val sourceText = printSource(source)
+    val sourceText = printSource(source, sourceFile)
 
     "[" ~ indent:
         List(sourceText, importData, defsData).join("," ~ Text.BreakLine)
@@ -585,8 +594,8 @@ object RawPrinter:
         "String ["  ~ value ~ "]"
 
   /** Print line lengths as comma-separated hexadecimal */
-  private def printSource(source: Source): Text =
-    "[" ~ source.file ~ "," ~ source.lineLengths.join("|") ~ "]"
+  private def printSource(source: Source, sourceFile: String): Text =
+    "[" ~ sourceFile ~ "," ~ source.lineLengths.join("|") ~ "]"
 
   private def printSpan(span: Span): Text =
     span.start ~ "," ~ span.length

--- a/stack-lang/tool/Build.scala
+++ b/stack-lang/tool/Build.scala
@@ -44,7 +44,13 @@ object Build:
             lib.copy(compileOptions = lib.compileOptions ++ docOptions(project, module))
 
           case app: CompileTask.AppTask =>
-            CompileTask.LibTask(app.sources, app.checkLibs, app.sastDir, docOptions(project, module))
+            CompileTask.LibTask(
+              app.sources,
+              app.checkLibs,
+              app.sastDir,
+              app.defaultSourceRoot,
+              app.compileOptions ++ docOptions(project, module),
+            )
       )
       Runner.doc(withDoc, outDir).map: _ =>
         Logger.info(s"[output] ${LogFormat.path(outDir)}\n")

--- a/stack-lang/tool/BuildPlan.scala
+++ b/stack-lang/tool/BuildPlan.scala
@@ -18,6 +18,7 @@ enum CompileTask:
     sources: List[Path],
     checkLibs: List[Path],
     outDir: Path,
+    defaultSourceRoot: Path,
     compileOptions: List[String] = Nil,
   )
   /** Compile sources into a runnable output (app build).
@@ -31,6 +32,7 @@ enum CompileTask:
     outFile: Path,
     sastDir: Path,
     resources: List[ResourceGroup],
+    defaultSourceRoot: Path,
     compileOptions: List[String],
   )
 

--- a/stack-lang/tool/Planner.scala
+++ b/stack-lang/tool/Planner.scala
@@ -63,6 +63,7 @@ object Planner:
 
                 SourcePaths.expand(spec.src, project0.dir).flatMap: sources =>
                   val compileOptions = ffiCompileOptions(spec) ++ spec.compileOptions
+                  val defaultSourceRoot = project0.dir.toAbsolutePath.normalize()
                   val task =
                     spec.kind match
                       case ModuleKind.Lib =>
@@ -71,6 +72,7 @@ object Planner:
                             sources,
                             checkLibs,
                             project0.sastDir(id),
+                            defaultSourceRoot,
                             compileOptions,
                           )
                         )
@@ -90,6 +92,7 @@ object Planner:
                                 project0.appOutFile(id, target),
                                 project0.sastDir(id),
                                 resources,
+                                defaultSourceRoot,
                                 compileOptions,
                               )
 

--- a/stack-lang/tool/Runner.scala
+++ b/stack-lang/tool/Runner.scala
@@ -24,7 +24,7 @@ object Runner:
       case app: CompileTask.AppTask =>
         info(s"[$action] ${moduleLabel(plan)}\n")
         runLib(
-          CompileTask.LibTask(app.sources, app.checkLibs, app.sastDir, app.compileOptions),
+          CompileTask.LibTask(app.sources, app.checkLibs, app.sastDir, app.defaultSourceRoot, app.compileOptions),
           jo,
           sentinelFile = dirSentinel(app.sastDir),
         ) match
@@ -48,7 +48,7 @@ object Runner:
         runLib(lib, jo, sentinelFile = dirSentinel(lib.outDir))
       case app: CompileTask.AppTask =>
         runLib(
-          CompileTask.LibTask(app.sources, app.checkLibs, app.sastDir, app.compileOptions),
+          CompileTask.LibTask(app.sources, app.checkLibs, app.sastDir, app.defaultSourceRoot, app.compileOptions),
           jo,
           sentinelFile = dirSentinel(app.sastDir),
         )
@@ -67,7 +67,7 @@ object Runner:
         runLib(lib, jo, sentinelFile = dirSentinel(outDir), requiredOutputs = List(docIndex))
       case app: CompileTask.AppTask =>
         runLib(
-          CompileTask.LibTask(app.sources, app.checkLibs, app.sastDir, app.compileOptions),
+          CompileTask.LibTask(app.sources, app.checkLibs, app.sastDir, app.defaultSourceRoot, app.compileOptions),
           jo,
           sentinelFile = dirSentinel(outDir),
           requiredOutputs = List(docIndex),
@@ -156,6 +156,9 @@ object Runner:
     args += "--sast"
     args += lib.outDir.toString
     lib.compileOptions.foreach(args += _)
+    if !lib.compileOptions.contains("--source-root") then
+      args += "--source-root"
+      args += lib.defaultSourceRoot.toString
     lib.sources.foreach(args += _.toString)
     lib.checkLibs.foreach: l =>
       args += "--lib"
@@ -170,6 +173,9 @@ object Runner:
     args += "--sast"
     args += app.sastDir.toString
     app.compileOptions.foreach(args += _)
+    if !app.compileOptions.contains("--source-root") then
+      args += "--source-root"
+      args += app.defaultSourceRoot.toString
     app.sources.foreach(args += _.toString)
     app.checkLibs.foreach: l =>
       args += "--lib"

--- a/tests/custom/doc-query/test.sh
+++ b/tests/custom/doc-query/test.sh
@@ -61,6 +61,16 @@ cd "$PROJECT_ROOT"
 # Absolute input paths must not leak into published SAST metadata or HTML docs.
 "$PROJECT_ROOT/bin/jo" compile --sast "$SAST_DIR" --source-root "$PROJECT_ROOT" \
     --use-runtime-api python "$PROJECT_ROOT/$API_FILE" > "$SAST_LOG"
+
+# Direct-source query locations use the same published path mapping as SAST.
+run_query --source-root "$PROJECT_ROOT" --query "DocQueryAPI.describe" \
+    --fields loc "$PROJECT_ROOT/$API_FILE" > "$PORTABLE_JSON"
+grep -q -- '"file": "tests/custom/doc-query/api.jo"' "$PORTABLE_JSON"
+if grep -F -q -- "$PROJECT_ROOT" "$PORTABLE_JSON"; then
+    echo "Absolute project path leaked into direct-source query output"
+    exit 1
+fi
+
 run_query --lib "$SAST_DIR" --query "DocQueryAPI.describe" --fields loc > "$PORTABLE_JSON"
 grep -q -- '"file": "tests/custom/doc-query/api.jo"' "$PORTABLE_JSON"
 if grep -R -F -q -- "$PROJECT_ROOT" "$SAST_DIR"; then

--- a/tests/custom/doc-query/test.sh
+++ b/tests/custom/doc-query/test.sh
@@ -58,6 +58,14 @@ cd "$PROJECT_ROOT"
 
 "$PROJECT_ROOT/bin/jo" compile --sast "$SAST_DIR" --use-runtime-api python "$API_FILE" > "$SAST_LOG"
 
+# Without an explicit root, the compiler uses its current working directory.
+run_query --query "DocQueryAPI.describe" --fields loc "$PROJECT_ROOT/$API_FILE" > "$PORTABLE_JSON"
+grep -q -- '"file": "tests/custom/doc-query/api.jo"' "$PORTABLE_JSON"
+if grep -F -q -- "$PROJECT_ROOT" "$PORTABLE_JSON"; then
+    echo "Absolute project path leaked with the default source root"
+    exit 1
+fi
+
 # Absolute input paths must not leak into published SAST metadata or HTML docs.
 "$PROJECT_ROOT/bin/jo" compile --sast "$SAST_DIR" --source-root "$PROJECT_ROOT" \
     --use-runtime-api python "$PROJECT_ROOT/$API_FILE" > "$SAST_LOG"
@@ -86,6 +94,22 @@ run_query --lib "$OUTSIDE_SAST_DIR" --query "DocQueryAPI.describe" --fields loc 
 grep -q -- '"file": "jo-doc-query-sast-[0-9]*-source.jo"' "$PORTABLE_JSON"
 if grep -R -F -q -- "$(dirname "$OUTSIDE_SOURCE")" "$OUTSIDE_SAST_DIR"; then
     echo "Containing directory of outside source leaked into SAST output"
+    exit 1
+fi
+
+run_query --source-root "$PROJECT_ROOT" --query "DocQueryAPI.describe" \
+    --fields loc "$OUTSIDE_SOURCE" > "$PORTABLE_JSON"
+grep -q -- '"file": "jo-doc-query-sast-[0-9]*-source.jo"' "$PORTABLE_JSON"
+if grep -F -q -- "$(dirname "$OUTSIDE_SOURCE")" "$PORTABLE_JSON"; then
+    echo "Containing directory of outside source leaked into direct-source query output"
+    exit 1
+fi
+
+"$PROJECT_ROOT/bin/jo" compile --doc --source-root "$PROJECT_ROOT" \
+    --use-runtime-api python --out "$PORTABLE_DOC_DIR" "$OUTSIDE_SOURCE" > /dev/null
+grep -q -- '"file": "jo-doc-query-sast-[0-9]*-source.jo"' "$PORTABLE_DOC_DIR/data.js"
+if grep -R -F -q -- "$(dirname "$OUTSIDE_SOURCE")" "$PORTABLE_DOC_DIR"; then
+    echo "Containing directory of outside source leaked into documentation"
     exit 1
 fi
 

--- a/tests/custom/doc-query/test.sh
+++ b/tests/custom/doc-query/test.sh
@@ -12,10 +12,14 @@ COMPANION_FILE="$REL_DIR/companion.jo"
 SAST_DIR="${TMPDIR:-/tmp}/jo-doc-query-sast-$$"
 SAST_LOG="$SAST_DIR.log"
 FAIL_LOG="$DIR/fail.log"
+PORTABLE_DOC_DIR="$SAST_DIR-doc"
+PORTABLE_JSON="$DIR/portable.json"
+OUTSIDE_SOURCE="$SAST_DIR-source.jo"
+OUTSIDE_SAST_DIR="$SAST_DIR-outside"
 
 cleanup() {
     rm -f "$DIR"/*.json
-    rm -rf "$SAST_DIR" "$SAST_LOG" "$FAIL_LOG"
+    rm -rf "$SAST_DIR" "$SAST_LOG" "$FAIL_LOG" "$PORTABLE_DOC_DIR" "$OUTSIDE_SOURCE" "$OUTSIDE_SAST_DIR"
 }
 
 finish() {
@@ -53,6 +57,35 @@ expect_fail() {
 cd "$PROJECT_ROOT"
 
 "$PROJECT_ROOT/bin/jo" compile --sast "$SAST_DIR" --use-runtime-api python "$API_FILE" > "$SAST_LOG"
+
+# Absolute input paths must not leak into published SAST metadata or HTML docs.
+"$PROJECT_ROOT/bin/jo" compile --sast "$SAST_DIR" --source-root "$PROJECT_ROOT" \
+    --use-runtime-api python "$PROJECT_ROOT/$API_FILE" > "$SAST_LOG"
+run_query --lib "$SAST_DIR" --query "DocQueryAPI.describe" --fields loc > "$PORTABLE_JSON"
+grep -q -- '"file": "tests/custom/doc-query/api.jo"' "$PORTABLE_JSON"
+if grep -R -F -q -- "$PROJECT_ROOT" "$SAST_DIR"; then
+    echo "Absolute project path leaked into SAST output"
+    exit 1
+fi
+
+# Sources outside the root retain only their basename.
+cp "$PROJECT_ROOT/$API_FILE" "$OUTSIDE_SOURCE"
+"$PROJECT_ROOT/bin/jo" compile --sast "$OUTSIDE_SAST_DIR" --source-root "$PROJECT_ROOT" \
+    --use-runtime-api python "$OUTSIDE_SOURCE" > "$SAST_LOG"
+run_query --lib "$OUTSIDE_SAST_DIR" --query "DocQueryAPI.describe" --fields loc > "$PORTABLE_JSON"
+grep -q -- '"file": "jo-doc-query-sast-[0-9]*-source.jo"' "$PORTABLE_JSON"
+if grep -R -F -q -- "$(dirname "$OUTSIDE_SOURCE")" "$OUTSIDE_SAST_DIR"; then
+    echo "Containing directory of outside source leaked into SAST output"
+    exit 1
+fi
+
+"$PROJECT_ROOT/bin/jo" compile --doc --source-root "$PROJECT_ROOT" \
+    --use-runtime-api python --out "$PORTABLE_DOC_DIR" "$PROJECT_ROOT/$API_FILE" > /dev/null
+grep -q -- '"file": "tests/custom/doc-query/api.jo"' "$PORTABLE_DOC_DIR/data.js"
+if grep -R -F -q -- "$PROJECT_ROOT" "$PORTABLE_DOC_DIR"; then
+    echo "Absolute project path leaked into documentation"
+    exit 1
+fi
 
 run_query --query "DocQueryAPI.*,DocQueryAPI.FileLike.readText" "$API_FILE" > "$DIR/structural.json"
 run_query --query "file:$API_FILE" "$API_FILE" "$EXTRA_FILE" > "$DIR/file.json"

--- a/tests/tool-build/doc/jo.steps
+++ b/tests/tool-build/doc/jo.steps
@@ -8,6 +8,12 @@ test -f .build/app/doc/index.html
 test -f .build/app/doc/data.js
 : ''
 
+grep -qF '"file": "src/Greeter.jo"' .build/app/doc/data.js
+: ''
+
+! grep -qF "$PWD" .build/app/doc/data.js
+: ''
+
 grep -qF '"title": "Doc Demo"' .build/app/doc/data.js
 : ''
 

--- a/tests/tool-build/source-root-override/jo.steps
+++ b/tests/tool-build/source-root-override/jo.steps
@@ -1,0 +1,16 @@
+rm -rf .build
+
+jo build
+: ''
+
+test "$(grep -c -x -- '--source-root' .build/lib/jo-1.0/sast.done)" -eq 1
+: ''
+
+awk 'previous == "--source-root" { found = ($0 == "src") } { previous = $0 } END { exit !found }' .build/lib/jo-1.0/sast.done
+: ''
+
+grep -a -q -- 'Main.jo' .build/lib/jo-1.0/sast/SourceRootOverride/Main.sast
+: ''
+
+! grep -a -q -- 'src/Main.jo' .build/lib/jo-1.0/sast/SourceRootOverride/Main.sast
+: ''

--- a/tests/tool-build/source-root-override/jo.toml
+++ b/tests/tool-build/source-root-override/jo.toml
@@ -1,0 +1,6 @@
+jo = "1.0"
+
+[module.lib]
+kind = "lib"
+src = ["src/"]
+compile-options = ["--source-root", "src"]

--- a/tests/tool-build/source-root-override/src/Main.jo
+++ b/tests/tool-build/source-root-override/src/Main.jo
@@ -1,0 +1,3 @@
+namespace SourceRootOverride
+
+def answer(): Int = 42

--- a/tests/tool-graph/no-deps/jo.toml
+++ b/tests/tool-graph/no-deps/jo.toml
@@ -4,3 +4,4 @@ jo = "1.0"
 kind = "app"
 platform = "python"
 src = ["src/"]
+compile-options = ["--source-root", "user-root"]

--- a/tests/tool-graph/no-deps/jo.txt
+++ b/tests/tool-graph/no-deps/jo.txt
@@ -1,2 +1,2 @@
 # root [app] (app)
-jo compile --python src/Main.jo -o .build/app/jo-1.0/target/app.py
+jo compile --python --source-root user-root src/Main.jo -o .build/app/jo-1.0/target/app.py


### PR DESCRIPTION
Suppport `--source-root` to not leak absolute path

## Summary

Suppport `--source-root` to not leak absolute path in docs and .sast files.

If a file is outside `--source-root`, only file name is shown.

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

Avoid leaking absolute path in docs and .sast files, which is an improvement.

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

No

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

