### PR TITLE
Make sure empty namespace is hidden in nav list

### DIFF
--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -320,10 +320,15 @@ const app = {
   },
 
   findNamespacePath(fullName) {
-    // Try exact match first
+    // An exact namespace match must win globally. A parent namespace can have
+    // a member with the same full name as a nested namespace (for example, a
+    // context parameter `a.foo` alongside namespace `a.foo`).
     for (const ns of this.nav.children) {
       if (ns.fullName === fullName) return ns.fullName;
-      // Check if it's a member of this namespace
+    }
+
+    // Check whether it is a direct member of a namespace.
+    for (const ns of this.nav.children) {
       if (ns.members) {
         for (const m of ns.members) {
           if (m.fullName === fullName) return ns.fullName;

--- a/stack-lang/doc/JsonEmitter.scala
+++ b/stack-lang/doc/JsonEmitter.scala
@@ -31,7 +31,9 @@ object JsonEmitter:
     out.println("{")
     out.println("""  "children": [""")
 
-    val grouped = units.groupBy(_.owner).toList.sortBy(_._1.fullName)
+    val grouped = units.groupBy(_.owner).toList
+      .filter((_, groupUnits) => collectNavMembers(groupUnits, includePrivate).nonEmpty)
+      .sortBy(_._1.fullName)
 
     var first = true
     for (sym, groupUnits) <- grouped do

--- a/tests/tool-build/doc/jo.steps
+++ b/tests/tool-build/doc/jo.steps
@@ -50,6 +50,12 @@ grep -qF 'Visible in the method list.' .build/app/doc/data.js
 grep -qF 'Fields</h3>' .build/app/doc/assets/app.js
 : ''
 
+python3 -c 'import json; p=".build/app/doc/data.js"; d=json.loads(open(p).read().removeprefix("var JO_DOC_DATA=")); names=[n["fullName"] for n in d["nav"]["children"]]; assert "HiddenFromDocNavigation" not in names; assert "Collision.Nested" in names'
+: ''
+
+grep -qF 'An exact namespace match must win globally.' .build/app/doc/assets/app.js
+: ''
+
 rm -rf .build/app/doc
 
 jo doc

--- a/tests/tool-build/doc/src/Collision.jo
+++ b/tests/tool-build/doc/src/Collision.jo
@@ -1,0 +1,3 @@
+namespace Collision
+
+param Nested: Int

--- a/tests/tool-build/doc/src/CollisionNested.jo
+++ b/tests/tool-build/doc/src/CollisionNested.jo
@@ -1,0 +1,3 @@
+namespace Collision.Nested
+
+def visible: Int = 1

--- a/tests/tool-build/doc/src/HiddenFromDocNavigation.jo
+++ b/tests/tool-build/doc/src/HiddenFromDocNavigation.jo
@@ -1,0 +1,3 @@
+namespace HiddenFromDocNavigation
+
+private def hidden: Int = 1


### PR DESCRIPTION
Make sure empty namespace is hidden in nav list

## What has changed

- Make sure empty namespace is hidden in nav list
- Make sure clicking namespace `a.foo` will not lead to context param `a.foo`

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

No

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

