### PR TITLE
Tweak docs

### DIFF
--- a/assets/doc/app.js
+++ b/assets/doc/app.js
@@ -8,6 +8,7 @@ const app = {
     'class': 'C',
     'interface': 'I',
     'function': 'F',
+    'annotation': 'A',
     'pattern': 'P',
     'object': 'O',
     'type': 'T',
@@ -69,11 +70,11 @@ const app = {
     const namespaceName = data.fullName || data.name;
     const heading = `<div class="nav-page-index-header">${namespaceName}</div>`;
 
-    const kindOrder = ['section', 'class', 'interface', 'abstract', 'object', 'type', 'pattern', 'function', 'context', 'method'];
+    const kindOrder = ['section', 'class', 'interface', 'abstract', 'object', 'type', 'pattern', 'function', 'annotation', 'context', 'method'];
     const kindLabel = {
       'section': 'Sections', 'class': 'Classes', 'interface': 'Interfaces', 'abstract': 'Abstract Types',
       'object': 'Objects', 'type': 'Types', 'pattern': 'Patterns',
-      'function': 'Functions', 'context': 'Context', 'method': 'Methods'
+      'function': 'Functions', 'annotation': 'Annotations', 'context': 'Context', 'method': 'Methods'
     };
 
     // Collect members by kind
@@ -85,7 +86,7 @@ const app = {
     };
 
     if (data.sections)  data.sections.forEach(s => addMember(s, 'section'));
-    if (data.functions) data.functions.forEach(f => addMember(f, 'function'));
+    if (data.functions) data.functions.forEach(f => addMember(f, f.kind || 'function'));
     if (data.classes)   data.classes.forEach(c => addMember(c, c.kind));
     if (data.types)     data.types.forEach(t => addMember(t, t.kind));
     if (data.patterns)  data.patterns.forEach(p => addMember(p, 'pattern'));
@@ -476,10 +477,11 @@ const app = {
   },
 
   groupByCategory(data) {
-    const categoryOrder = ['section', 'class', 'interface', 'abstract', 'object', 'type', 'pattern', 'function', 'context'];
+    const categoryOrder = ['section', 'class', 'interface', 'abstract', 'object', 'type', 'pattern', 'function', 'annotation', 'context'];
     const categoryLabels = {
       section: 'Sections', class: 'Classes', interface: 'Interfaces', abstract: 'Abstract Types',
-      object: 'Objects', type: 'Types', pattern: 'Patterns', function: 'Functions', context: 'Context'
+      object: 'Objects', type: 'Types', pattern: 'Patterns', function: 'Functions',
+      annotation: 'Annotations', context: 'Context'
     };
     const categories = new Map();
 
@@ -499,7 +501,7 @@ const app = {
       });
     }
     if (data.types) data.types.forEach(t => addItem(t, t.kind));
-    if (data.functions) data.functions.forEach(f => addItem(f, 'function'));
+    if (data.functions) data.functions.forEach(f => addItem(f, f.kind || 'function'));
     if (data.patterns) data.patterns.forEach(p => addItem(p, 'pattern'));
     if (data.objects) data.objects.forEach(o => addItem(o, 'object'));
     if (data.contexts) data.contexts.forEach(c => addItem(c, 'context'));
@@ -791,8 +793,8 @@ const app = {
       }
     }
 
-    // Return type
-    if (item.returnType) {
+    // Return type - an annotation declares none, so suppress the implicit Unit
+    if (item.returnType && kind !== 'annotation') {
       sig += `: ${this.renderType(item.returnType)}`;
     }
 

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -468,6 +468,7 @@ h3 {
 .kind-class     { background: linear-gradient(135deg, #3b82f6, #6366f1); color: #fff; }
 .kind-interface { background: linear-gradient(135deg, #8b5cf6, #a855f7); color: #fff; }
 .kind-function  { background: linear-gradient(135deg, #10b981, #059669); color: #fff; }
+.kind-annotation{ background: linear-gradient(135deg, #84cc16, #4d7c0f); color: #fff; }
 .kind-pattern   { background: linear-gradient(135deg, #ec4899, #f43f5e); color: #fff; }
 .kind-type      { background: linear-gradient(135deg, #6366f1, #4f46e5); color: #fff; }
 .kind-abstract  { background: linear-gradient(135deg, #64748b, #475569); color: #fff; }
@@ -509,6 +510,7 @@ h3 {
 
 /* ── Kind-specific accent borders ────────────────────────────────────────── */
 .kind-def-function  { border-left-color: #22c55e; }
+.kind-def-annotation{ border-left-color: #84cc16; }
 .kind-def-section   { border-left-color: #7c3aed; }
 .kind-def-class     { border-left-color: #3b82f6; }
 .kind-def-interface { border-left-color: #a78bfa; }

--- a/stack-lang/doc/JsonEmitter.scala
+++ b/stack-lang/doc/JsonEmitter.scala
@@ -94,7 +94,7 @@ object JsonEmitter:
 
         // Skip singleton accessor functions (they have Flags.Object)
         case fd: FunDef if !fd.symbol.isMethod && !fd.symbol.is(Flags.Object) =>
-          addMember(fd.symbol.name, fd.symbol.fullName, "function")
+          addMember(fd.symbol.name, fd.symbol.fullName, funKind(fd.symbol))
 
         case pd: PatDef if !pd.resultType.tpe.isSingletonObjectType =>
           addMember(pd.symbol.name, pd.symbol.fullName, "pattern")
@@ -162,7 +162,7 @@ object JsonEmitter:
           // Skip singleton accessor functions (they have Flags.Object)
           case fd: FunDef if !fd.symbol.isMethod && !fd.symbol.is(Flags.Object) =>
             val doc = defn.index.docComment(fd.symbol).headOption
-            emitSymbol(fd.symbol, "function", doc)
+            emitSymbol(fd.symbol, funKind(fd.symbol), doc)
 
           case pd: PatDef if !pd.resultType.tpe.isSingletonObjectType =>
             val doc = defn.index.docComment(pd.symbol).headOption
@@ -610,6 +610,8 @@ object JsonEmitter:
       out.println(s"""$indent{""")
       out.println(s"""$indent  "name": ${jsonString(sym.name)},""")
       out.println(s"""$indent  "fullName": ${jsonString(sym.fullName)},""")
+      if sym.isAnnotation then
+        out.println(s"""$indent  "kind": "annotation",""")
 
       // Type params
       if fd.tparams.nonEmpty then
@@ -738,6 +740,14 @@ object JsonEmitter:
 
         val sym = sec.symbol
         out.print(s"""$indent{ "name": ${jsonString(sym.name)}, "fullName": ${jsonString(sym.fullName)} }""")
+
+  /** The documented kind of a top-level term.
+    *
+    * `annotation` declarations are lowered to a FunDef carrying Flags.Annotation,
+    * so without this they would be published as ordinary functions.
+    */
+  private def funKind(sym: Symbol): String =
+    if sym.isAnnotation then "annotation" else "function"
 
   /** Check if a section has any visible (non-private unless includePrivate) members */
   private def hasVisibleMembers(sec: Section, includePrivate: Boolean): Boolean =

--- a/stack-lang/doc/JsonEmitter.scala
+++ b/stack-lang/doc/JsonEmitter.scala
@@ -131,8 +131,13 @@ object JsonEmitter:
       val defn = summon[Definitions]
 
       def processDef(d: Def): Unit =
+        // A private container hides everything inside it, so bail out before
+        // recursing. Without this a `private section` still contributed all of
+        // its members to the search index, even though nav excluded it.
+        if !includePrivate && d.symbol.isPrivate then return
+
         d match
-          case cd: ClassDef if includePrivate || !cd.symbol.isPrivate =>
+          case cd: ClassDef =>
             val kind =
               if cd.symbol.is(Flags.Object) then "object"
               else if cd.symbol.isInterface then "interface"
@@ -145,7 +150,7 @@ object JsonEmitter:
               val methodDoc = defn.index.docComment(meth.symbol).headOption
               emitSymbol(meth.symbol, "method", methodDoc)
 
-          case id: InterfaceDef if includePrivate || !id.symbol.isPrivate =>
+          case id: InterfaceDef =>
             val doc = defn.index.docComment(id.symbol).headOption
             emitSymbol(id.symbol, "interface", doc)
 
@@ -163,7 +168,7 @@ object JsonEmitter:
             val doc = defn.index.docComment(pd.symbol).headOption
             emitSymbol(pd.symbol, "pattern", doc)
 
-          case td: TypeDef if includePrivate || !td.symbol.isPrivate =>
+          case td: TypeDef =>
             val kind = if td.symbol.is(Flags.Defer) then "abstract" else "type"
             val doc = defn.index.docComment(td.symbol).headOption
             emitSymbol(td.symbol, kind, doc)
@@ -192,7 +197,10 @@ object JsonEmitter:
     def collectFromDefs(defs: List[Def]): Unit =
       for d <- defs do
         d match
-          case sec: Section if hasVisibleMembers(sec, includePrivate) =>
+          // A private section is not published, and neither is anything nested
+          // inside it, so do not descend into one either.
+          case sec: Section
+          if (includePrivate || !sec.symbol.isPrivate) && hasVisibleMembers(sec, includePrivate) =>
             sections += sec
             collectFromDefs(sec.defs)
           case _ => ()

--- a/stack-lang/parsing/Scanner.scala
+++ b/stack-lang/parsing/Scanner.scala
@@ -37,6 +37,7 @@ class Scanner(stream: CharStream)(using Reporter, Source):
       case Token.CLASS | Token.INTERFACE | Token.OBJECT | Token.EXTENSION => true
       case Token.PARAM | Token.PATTERN | Token.UNION => true
       case Token.SECTION | Token.AUTO | Token.VIEW => true
+      case Token.ANNOTATION => true
       case Token.AT => true
       case _ => false
 

--- a/stack-lang/typing/Namer.scala
+++ b/stack-lang/typing/Namer.scala
@@ -1417,6 +1417,7 @@ class Namer(using Config) extends Applications with SelectionTyper:
 
     val index = lazyDefn.index
     index.addLazy(funSym, computeInfo, () => computeInfo())
+    index.setDocComment(funSym, adef.docComment)
 
     Checks.add:
       withDefn:

--- a/tests/custom/doc-annotation/api.jo
+++ b/tests/custom/doc-annotation/api.jo
@@ -1,0 +1,11 @@
+namespace jo
+
+//[ Mark a definition as experimental
+  !
+  ! The annotation carries a stability level so tooling can decide whether to
+  ! surface the definition.
+//]
+annotation docTestExperimental(level: Int)
+
+//[ Mark a definition as deprecated. //]
+annotation docTestDeprecated

--- a/tests/custom/doc-annotation/test.sh
+++ b/tests/custom/doc-annotation/test.sh
@@ -94,4 +94,30 @@ if ! grep -q -- '"fullName": "jo.compile.intrinsic", "kind": "annotation", "summ
     exit 1
 fi
 
+# Every kind the emitter can produce needs a `.kind-<kind>` badge rule in the
+# stylesheet, or the viewer renders an unstyled, invisible badge. This is how
+# "annotation" shipped with no badge once it became its own kind.
+CSS="$(dirname "$STDLIB_DATA")/assets/style.css"
+[ -f "$CSS" ] || CSS="$(dirname "$STDLIB_DATA")/style.css"
+
+if [ ! -f "$CSS" ]; then
+    echo "Could not find the generated stylesheet next to $STDLIB_DATA"
+    exit 1
+fi
+
+# Only symbol entries, which are the ones that get a badge. Matching on the
+# `"fullName": ..., "kind": ...` pair skips the type descriptors in the symbols
+# block, which reuse the "kind" key for `ref`, `applied`, `union` and friends.
+# `leaf` is the nav tree's namespace node and carries no badge.
+missing=""
+for kind in $(grep -o '"fullName": "[^"]*", "kind": "[a-z]*"' "$STDLIB_DATA" \
+                | sed 's/.*"kind": "//; s/"//' | sort -u | grep -v '^leaf$'); do
+    grep -q "\.kind-$kind[[:space:]]*{" "$CSS" || missing="$missing $kind"
+done
+
+if [ -n "$missing" ]; then
+    echo "Kinds emitted with no .kind-<kind> badge rule in style.css:$missing"
+    exit 1
+fi
+
 echo "  ✓ All tests passed for $TEST_NAME"

--- a/tests/custom/doc-annotation/test.sh
+++ b/tests/custom/doc-annotation/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Regression test: doc comments on `annotation` declarations must reach the
-# generated documentation.
+# Regression test: `annotation` declarations must be documented correctly --
+# they must carry their doc comment, and be reported as kind "annotation"
+# rather than as an ordinary function.
 #
 # Two separate defects used to drop them:
 #   1. Scanner.isDefStartToken did not list Token.ANNOTATION, so the scanner
@@ -9,6 +10,10 @@
 #   2. Namer.transformAnnotationDef never called index.setDocComment, so even a
 #      doc that survived parsing was not recorded for the symbol.
 # Both must stay fixed for the summary and body below to appear.
+#
+# A third defect published annotations with kind "function": they are lowered
+# to a FunDef carrying Flags.Annotation, and the doc emitters did not look at
+# that flag.
 
 set -euo pipefail
 
@@ -39,16 +44,30 @@ cd "$PROJECT_ROOT"
 
 DATA="$DOC_DIR/data.js"
 
-# The summary line is the first line of the doc comment.
-if ! grep -q -- '"fullName": "jo.docTestExperimental", "kind": "function", "summary": "Mark a definition as experimental"' "$DATA"; then
-    echo "Missing summary for jo.docTestExperimental"
+# The summary line is the first line of the doc comment, and the kind must be
+# "annotation" -- not "function".
+if ! grep -q -- '"fullName": "jo.docTestExperimental", "kind": "annotation", "summary": "Mark a definition as experimental"' "$DATA"; then
+    echo "Wrong kind or missing summary for jo.docTestExperimental"
     grep -o '"fullName": "jo.docTestExperimental"[^}]*}' "$DATA" || echo "  (symbol not found at all)"
     exit 1
 fi
 
 # A single-line doc comment must work too.
-if ! grep -q -- '"fullName": "jo.docTestDeprecated", "kind": "function", "summary": "Mark a definition as deprecated."' "$DATA"; then
-    echo "Missing summary for jo.docTestDeprecated"
+if ! grep -q -- '"fullName": "jo.docTestDeprecated", "kind": "annotation", "summary": "Mark a definition as deprecated."' "$DATA"; then
+    echo "Wrong kind or missing summary for jo.docTestDeprecated"
+    grep -o '"fullName": "jo.docTestDeprecated"[^}]*}' "$DATA" || echo "  (symbol not found at all)"
+    exit 1
+fi
+
+# The nav tree reports the kind as well.
+if ! grep -q -- '"fullName": "jo.docTestExperimental", "kinds": \["annotation"\]' "$DATA"; then
+    echo "Nav entry for jo.docTestExperimental is not kind annotation"
+    exit 1
+fi
+
+# Entries in the symbols block carry the kind so the viewer can group them.
+if ! grep -q -- '"kind": "annotation"' "$DATA"; then
+    echo "symbols block does not tag annotations with their kind"
     exit 1
 fi
 
@@ -65,12 +84,12 @@ STDLIB_DOC_DIR="$DOC_DIR-stdlib"
 
 STDLIB_DATA="$STDLIB_DOC_DIR/data.js"
 
-if ! grep -q -- '"fullName": "jo.shadow", "kind": "function", "summary": "Mark an extension method' "$STDLIB_DATA"; then
+if ! grep -q -- '"fullName": "jo.shadow", "kind": "annotation", "summary": "Mark an extension method' "$STDLIB_DATA"; then
     echo "Missing summary for the stdlib annotation jo.shadow"
     exit 1
 fi
 
-if ! grep -q -- '"fullName": "jo.compile.intrinsic", "kind": "function", "summary": "Mark an intrinsic definition"' "$STDLIB_DATA"; then
+if ! grep -q -- '"fullName": "jo.compile.intrinsic", "kind": "annotation", "summary": "Mark an intrinsic definition"' "$STDLIB_DATA"; then
     echo "Missing summary for the stdlib annotation jo.compile.intrinsic"
     exit 1
 fi

--- a/tests/custom/doc-annotation/test.sh
+++ b/tests/custom/doc-annotation/test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Regression test: doc comments on `annotation` declarations must reach the
+# generated documentation.
+#
+# Two separate defects used to drop them:
+#   1. Scanner.isDefStartToken did not list Token.ANNOTATION, so the scanner
+#      discarded the comments preceding an annotation declaration.
+#   2. Namer.transformAnnotationDef never called index.setDocComment, so even a
+#      doc that survived parsing was not recorded for the symbol.
+# Both must stay fixed for the summary and body below to appear.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$DIR/../../.." && pwd)"
+TEST_NAME="$(basename "$DIR")"
+API_FILE="tests/custom/doc-annotation/api.jo"
+DOC_DIR="${TMPDIR:-/tmp}/jo-doc-annotation-$$"
+
+cleanup() { rm -rf "$DOC_DIR" "$DOC_DIR-stdlib"; }
+
+finish() {
+    local status=$?
+    if [ "$status" -eq 0 ]; then
+        cleanup
+    else
+        echo "  failed; documentation output left in $DOC_DIR"
+    fi
+}
+
+trap finish EXIT
+
+echo "Testing $TEST_NAME"
+
+cd "$PROJECT_ROOT"
+
+"$PROJECT_ROOT/bin/jo" compile --doc --out "$DOC_DIR" "$API_FILE" > /dev/null
+
+DATA="$DOC_DIR/data.js"
+
+# The summary line is the first line of the doc comment.
+if ! grep -q -- '"fullName": "jo.docTestExperimental", "kind": "function", "summary": "Mark a definition as experimental"' "$DATA"; then
+    echo "Missing summary for jo.docTestExperimental"
+    grep -o '"fullName": "jo.docTestExperimental"[^}]*}' "$DATA" || echo "  (symbol not found at all)"
+    exit 1
+fi
+
+# A single-line doc comment must work too.
+if ! grep -q -- '"fullName": "jo.docTestDeprecated", "kind": "function", "summary": "Mark a definition as deprecated."' "$DATA"; then
+    echo "Missing summary for jo.docTestDeprecated"
+    exit 1
+fi
+
+# The `!` continuation lines must survive into the full doc body.
+if ! grep -q -- 'The annotation carries a stability level so tooling can decide whether to' "$DATA"; then
+    echo "Continuation lines of the annotation doc comment were dropped"
+    exit 1
+fi
+
+# The stdlib's own annotations must carry their docs as well. Documenting a
+# single source file does not pull in stdlib symbols, so document lib/ itself.
+STDLIB_DOC_DIR="$DOC_DIR-stdlib"
+"$PROJECT_ROOT/bin/jo" compile --doc --no-stdlib --out "$STDLIB_DOC_DIR" lib/*.jo lib/**/*.jo > /dev/null
+
+STDLIB_DATA="$STDLIB_DOC_DIR/data.js"
+
+if ! grep -q -- '"fullName": "jo.shadow", "kind": "function", "summary": "Mark an extension method' "$STDLIB_DATA"; then
+    echo "Missing summary for the stdlib annotation jo.shadow"
+    exit 1
+fi
+
+if ! grep -q -- '"fullName": "jo.compile.intrinsic", "kind": "function", "summary": "Mark an intrinsic definition"' "$STDLIB_DATA"; then
+    echo "Missing summary for the stdlib annotation jo.compile.intrinsic"
+    exit 1
+fi
+
+echo "  ✓ All tests passed for $TEST_NAME"

--- a/tests/custom/doc-private-section/api.jo
+++ b/tests/custom/doc-private-section/api.jo
@@ -1,0 +1,19 @@
+namespace docprivate
+
+//[ A section whose members belong in the published docs. //]
+section PublicHelpers
+  //[ Double `x`. //]
+  def twice(x: Int): Int = x * 2
+end
+
+//[ An implementation detail that must not be published. //]
+private section InternalHelpers
+  //[ Triple `x`. //]
+  def thrice(x: Int): Int = x * 3
+
+  class Hidden(tag: Int)
+    def tagged: Int = tag
+  end
+
+  type HiddenAlias = Int
+end

--- a/tests/custom/doc-private-section/test.sh
+++ b/tests/custom/doc-private-section/test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Regression test: members of a `private section` must stay out of the
+# generated documentation.
+#
+# The nav tree already excluded private sections, but the search index did not:
+# JsonEmitter.emitSearch recursed into a section's members whenever the section
+# had visible members, without first checking whether the section itself was
+# private. Every member of `private section MapTree`, `SetTree`, `ListImpl` and
+# friends was therefore searchable in the published stdlib docs.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$DIR/../../.." && pwd)"
+TEST_NAME="$(basename "$DIR")"
+API_FILE="tests/custom/doc-private-section/api.jo"
+DOC_DIR="${TMPDIR:-/tmp}/jo-doc-private-section-$$"
+
+cleanup() { rm -rf "$DOC_DIR"; }
+
+finish() {
+    local status=$?
+    if [ "$status" -eq 0 ]; then
+        cleanup
+    else
+        echo "  failed; documentation output left in $DOC_DIR"
+    fi
+}
+
+trap finish EXIT
+
+echo "Testing $TEST_NAME"
+
+cd "$PROJECT_ROOT"
+
+"$PROJECT_ROOT/bin/jo" compile --doc --out "$DOC_DIR" "$API_FILE" > /dev/null
+
+DATA="$DOC_DIR/data.js"
+
+# Public members are published.
+for want in \
+    '"fullName": "docprivate.PublicHelpers"' \
+    '"fullName": "docprivate.PublicHelpers.twice"'
+do
+    if ! grep -q -- "$want" "$DATA"; then
+        echo "Public symbol missing from documentation: $want"
+        exit 1
+    fi
+done
+
+# Nothing from the private section is published, in nav or in search.
+for unwanted in \
+    "InternalHelpers" \
+    "thrice" \
+    "Hidden" \
+    "HiddenAlias"
+do
+    if grep -q -- "$unwanted" "$DATA"; then
+        echo "Private section member leaked into documentation: $unwanted"
+        grep -o "\"fullName\": \"[^\"]*$unwanted[^\"]*\"" "$DATA" | sort -u | head
+        exit 1
+    fi
+done
+
+echo "  ✓ All tests passed for $TEST_NAME"


### PR DESCRIPTION
Tweak docs

## What has changed

- Hide private items from search
- Make sure annotations have doc attached
- Display annotations in docs properly

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

No

<!-- Does this affect compatibility? If so, describe. -->

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

