### PR TITLE
Publish runtime docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,14 +50,21 @@ This produces:
 
 - [ ] Tarball and checksum created
 
-The standard library API docs ship as a release asset, which is what
+The library API docs ship as a release asset, which is what
 `jo-lang.org/stdlib/X.Y.Z/` is built from. Generate them with `bin/doc` rather
 than the released compiler: it runs the generator out of the working tree, so
 the bundle uses the current documentation system including any design changes
 made since the last release.
 
+The bundle covers all four libraries: the standard library, plus the `jo.py`,
+`jo.rb` and `jo.js` runtime FFI APIs. The runtime files are listed explicitly
+because only the FFI surface is published -- the rest of each `runtime/`
+directory is backend plumbing, not API.
+
 ```sh
-bin/doc --no-stdlib $(find lib -name '*.jo') \
+bin/doc --no-stdlib \
+  $(find lib -name '*.jo') \
+  runtime/python/py.jo runtime/ruby/rb.jo runtime/javascript/js.jo \
   --title "Jo Standard Library" \
   --project-version X.Y.Z \
   --readme lib/README.md \

--- a/assets/doc/style.css
+++ b/assets/doc/style.css
@@ -629,6 +629,29 @@ h3 {
 .doc a       { color: var(--brand-1); text-decoration: none; }
 .doc a:hover { text-decoration: underline; }
 
+.doc table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.9rem 0 1.2rem;
+  font-size: 0.94rem;
+}
+.doc th,
+.doc td {
+  text-align: left;
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.doc th {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+.doc tbody tr:last-child td { border-bottom: none; }
+.doc tbody tr:hover { background: var(--bg-secondary); }
+
 .doc h1 { font-size: 1.75rem; margin-bottom: 1rem; }
 .doc h2 { font-size: 1.25rem; margin-top: 1.5rem; }
 .doc h3 { font-size: 1.05rem; margin-top: 1.25rem; }

--- a/ci
+++ b/ci
@@ -204,8 +204,15 @@ background_task() {
     bin/jo compile --reg --report-time tests/pos/fact.jo || error "jo compile --reg"
 
     # check doc
-    bin/doc --no-stdlib $(find lib -name '*.jo') --title "Jo Standard Library" --out libdocs || error "bin/doc"
-    bin/jo compile --doc --no-stdlib $(find lib -name '*.jo') --title "Jo Standard Library" --out stdlib-doc || error "doc"
+    #
+    # Same source list as the release bundle in RELEASE.md: the standard library
+    # plus the three runtime FFI APIs. `--readme` is passed so a home page that
+    # breaks the generator, or markdown that mangles its inline SVG, fails here
+    # rather than at release time.
+    DOC_SOURCES="$(find $DIR/lib -name '*.jo') $DIR/runtime/python/py.jo $DIR/runtime/ruby/rb.jo $DIR/runtime/javascript/js.jo"
+
+    bin/doc --no-stdlib $DOC_SOURCES --title "Jo Standard Library" --readme $DIR/lib/README.md --out libdocs || error "bin/doc"
+    bin/jo compile --doc --no-stdlib $DOC_SOURCES --title "Jo Standard Library" --readme $DIR/lib/README.md --out stdlib-doc || error "doc"
 
     ################################################################################
     # AST printer round-trip

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,9 +1,8 @@
 # Jo Standard Library
 
 Jo ships **four libraries**, and this bundle documents all of them. They are not
-peers: one is confined, and three are not. Which is which decides what a program
-built on them is able to do. Everything under `jo` except `jo.py`, `jo.rb` and
-`jo.js` is the standard library.
+peers: one is confined, and three are not. Except `jo.py`, `jo.rb` and
+`jo.js`, everything under `jo` is the standard library.
 
 <svg viewBox="0 0 760 360" role="img" width="100%"
      aria-label="A wall separates two worlds. On the green confined side sits the jo standard library, which has no FFI, no ambient authority and cannot originate an effect; confinement is transitive, so confined code may depend only on confined code. On the orange trusted side, the jo.py, jo.rb and jo.js runtime libraries reach the host platform: filesystem, network, processes and any module. The only opening in the wall is a gate through which capabilities pass into confined code at link time. A direct route from confined code to the host is blocked."
@@ -69,7 +68,7 @@ built on them is able to do. Everything under `jo` except `jo.py`, `jo.rb` and
 
 ## The four libraries
 
-The standard library spans five namespaces; each runtime API is a single one.
+The standard library spans five namespaces. Each runtime API is a single namespace.
 
 | Library | Namespaces | Status |
 | --- | --- | --- |
@@ -100,10 +99,10 @@ rejects the attempt.
 
 Confinement is **transitive**, and that is what makes it worth anything. A
 confined library may depend only on other confined libraries, so the property
-holds across the whole dependency graph rather than at its top. Import anything
-that transitively reaches a trusted library and compilation fails with a type
-error — so no dependency, however deep, can quietly widen what confined code is
-able to do.
+holds across the whole dependency graph rather than at its top.
+Import anything that transitively reaches a trusted library that uses FFI will
+be a compilation error — so transitive dependency cannot break the confinement
+property.
 
 So every real side effect a Jo program performs originates in the trusted world,
 where FFI is available, and crosses into confined code as a capability resolved
@@ -119,10 +118,12 @@ this code is able to break the guarantees the confined world rests on, so it has
 to be code you are willing to vouch for.
 
 They exist to *build* capabilities, by calling the host platform directly.
-`py.module` imports any Python module, `subprocess` included; `rb.require` loads
-any Ruby library; `js.global` reaches the whole JavaScript environment.
 
-None of it is reachable unless the compilation asks for it:
+- `py.module` imports any Python module, `subprocess` included;
+- `rb.require` loads any Ruby library;
+- `js.global` reaches the whole JavaScript environment.
+
+The FFI libraries are guarded behind the compilation flag `--user-runtime-api`:
 
 ```sh
 jo compile --python app.jo --use-runtime-api python

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,7 +1,87 @@
 # Jo Standard Library
 
-The standard library is confined code. It contains no FFI, and it cannot
-originate a side effect. Everything defined here is computation over values.
+Jo ships **four libraries**, and this bundle documents all of them. They are not
+peers: one is confined, and three are not. Which is which decides what a program
+built on them is able to do.
+
+<svg viewBox="0 0 760 360" role="img" width="100%"
+     aria-label="A wall separates two worlds. On the green confined side sits the jo standard library, which has no FFI, no ambient authority and cannot originate an effect; confinement is transitive, so confined code may depend only on confined code. On the orange trusted side, the jo.py, jo.rb and jo.js runtime libraries reach the host platform: filesystem, network, processes and any module. The only opening in the wall is a gate through which capabilities pass into confined code at link time. A direct route from confined code to the host is blocked."
+     style="max-width:760px;color:currentColor">
+  <defs>
+    <marker id="cap-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+    <marker id="dep-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" fill-opacity="0.6"/>
+    </marker>
+  </defs>
+  <rect x="8" y="44" width="292" height="272" rx="10"
+        fill="#16a34a" fill-opacity="0.10" stroke="#16a34a" stroke-opacity="0.55"/>
+  <text x="26" y="70" font-size="12" font-weight="700" letter-spacing="1.4"
+        fill="#16a34a">CONFINED</text>
+  <rect x="28" y="88" width="252" height="196" rx="9"
+        fill="#16a34a" fill-opacity="0.18" stroke="#16a34a" stroke-opacity="0.7"/>
+  <text x="46" y="144" font-size="34" font-weight="700" fill="currentColor">jo</text>
+  <text x="46" y="170" font-size="14" fill="currentColor" fill-opacity="0.8">the standard library</text>
+  <line x1="46" y1="188" x2="262" y2="188" stroke="#16a34a" stroke-opacity="0.45" stroke-width="1"/>
+  <text x="46" y="214" font-size="12" fill="currentColor" fill-opacity="0.75">no FFI</text>
+  <text x="46" y="236" font-size="12" fill="currentColor" fill-opacity="0.75">no ambient authority</text>
+  <text x="46" y="258" font-size="12" fill="currentColor" fill-opacity="0.75">cannot originate an effect</text>
+  <text x="28" y="306" font-size="10" fill="#16a34a" fill-opacity="0.95">transitive: confined code may depend only on confined code</text>
+  <rect x="356" y="36" width="8" height="134" rx="2" fill="currentColor" fill-opacity="0.38"/>
+  <rect x="356" y="214" width="8" height="112" rx="2" fill="currentColor" fill-opacity="0.38"/>
+  <line x1="416" y1="192" x2="284" y2="192" stroke="currentColor" stroke-opacity="0.8"
+        stroke-width="1.8" marker-end="url(#cap-arrow)"/>
+  <text x="360" y="180" font-size="10" text-anchor="middle" font-weight="700"
+        fill="currentColor" fill-opacity="0.85">capabilities</text>
+  <text x="360" y="209" font-size="10" text-anchor="middle"
+        fill="currentColor" fill-opacity="0.6">at link time</text>
+  <line x1="302" y1="264" x2="346" y2="264" stroke="#dc2626" stroke-opacity="0.5"
+        stroke-width="1.4" stroke-dasharray="4 4"/>
+  <line x1="353" y1="257" x2="367" y2="271" stroke="#dc2626" stroke-width="2.6" stroke-linecap="round"/>
+  <line x1="367" y1="257" x2="353" y2="271" stroke="#dc2626" stroke-width="2.6" stroke-linecap="round"/>
+  <text x="360" y="292" font-size="10" text-anchor="middle" fill="#dc2626">no direct route</text>
+  <rect x="420" y="44" width="332" height="272" rx="10"
+        fill="#ea580c" fill-opacity="0.10" stroke="#ea580c" stroke-opacity="0.55" stroke-dasharray="5 4"/>
+  <text x="438" y="70" font-size="12" font-weight="700" letter-spacing="1.4"
+        fill="#ea580c">TRUSTED</text>
+  <rect x="440" y="86" width="292" height="36" rx="7"
+        fill="#ea580c" fill-opacity="0.16" stroke="#ea580c" stroke-opacity="0.6"/>
+  <text x="456" y="109" font-size="13" fill="currentColor"><tspan font-weight="700">jo.py</tspan> — Python interop</text>
+  <rect x="440" y="128" width="292" height="36" rx="7"
+        fill="#ea580c" fill-opacity="0.16" stroke="#ea580c" stroke-opacity="0.6"/>
+  <text x="456" y="151" font-size="13" fill="currentColor"><tspan font-weight="700">jo.rb</tspan> — Ruby interop</text>
+  <rect x="440" y="170" width="292" height="36" rx="7"
+        fill="#ea580c" fill-opacity="0.16" stroke="#ea580c" stroke-opacity="0.6"/>
+  <text x="456" y="193" font-size="13" fill="currentColor"><tspan font-weight="700">jo.js</tspan> — JavaScript interop</text>
+  <line x1="586" y1="206" x2="586" y2="230" stroke="currentColor" stroke-opacity="0.55"
+        stroke-width="1.4" marker-end="url(#dep-arrow)"/>
+  <rect x="440" y="234" width="292" height="60" rx="8"
+        fill="#ea580c" fill-opacity="0.07" stroke="#ea580c" stroke-opacity="0.45" stroke-dasharray="4 3"/>
+  <text x="456" y="258" font-size="13" font-weight="700" fill="currentColor" fill-opacity="0.9">the host platform</text>
+  <text x="456" y="278" font-size="11" fill="currentColor" fill-opacity="0.7">filesystem · network · processes · any module</text>
+  <text x="380" y="342" font-size="11" text-anchor="middle"
+        fill="currentColor" fill-opacity="0.7">a runtime library is reachable only under --use-runtime-api</text>
+</svg>
+
+## Stability
+
+| Library | Status |
+| --- | --- |
+| [`jo`](#/jo) — standard library | Stabilizing |
+| [`jo.py`](#/jo.py) — Python interop | Stabilizing |
+| [`jo.rb`](#/jo.rb) — Ruby interop | Experimental |
+| [`jo.js`](#/jo.js) — JavaScript interop | Experimental |
+
+*Stabilizing* means the shape is settling: breaking changes are not intended, but
+expect some to slip through. *Experimental* means the API may change at any time.
+
+## The standard library is confined
+
+The standard library contains no FFI, and it cannot originate a side effect.
+Everything defined here is computation over values.
 
 Effects reach it as capabilities. `jo.IO` *declares* them rather than
 implementing them:
@@ -15,15 +95,40 @@ library supplied that `stdout`. Code that is never given the capability cannot
 reach standard output at all — not by convention, but because the compiler
 rejects the attempt.
 
+Confinement is **transitive**, and that is what makes it worth anything. A
+confined library may depend only on other confined libraries, so the property
+holds across the whole dependency graph rather than at its top. Import anything
+that transitively reaches a trusted library and compilation fails with a type
+error — so no dependency, however deep, can quietly widen what confined code is
+able to do.
+
 So every real side effect a Jo program performs originates in the trusted world,
 where FFI is available, and crosses into confined code as a capability resolved
 at link time. See
 [Two-World Architecture](https://jo-lang.org/security/two-worlds) for how that
 boundary is enforced.
 
-## Documentation coverage
+## The runtime libraries are trusted
 
-These pages are generated from doc comments in the library sources. Coverage is
-not complete: some public APIs are not documented yet, and others describe what
-an operation does without saying when you would reach for it. Both are being
-filled in over coming releases.
+[`jo.py`](#/jo.py), [`jo.rb`](#/jo.rb) and [`jo.js`](#/jo.js) are the trusted
+side of that boundary. *Trusted* is a classification, not a reassurance: it means
+this code is able to break the guarantees the confined world rests on, so it has
+to be code you are willing to vouch for.
+
+They exist to *build* capabilities, by calling the host platform directly.
+`py.module` imports any Python module, `subprocess` included; `rb.require` loads
+any Ruby library; `js.global` reaches the whole JavaScript environment.
+
+None of it is reachable unless the compilation asks for it:
+
+```sh
+jo compile --python app.jo --use-runtime-api python
+```
+
+Without that flag the names do not resolve — the guarantee is enforced by the
+compiler, not by which pages you read. The flag names a single backend, so one
+compilation can reach at most one of the three.
+
+**Do not enable a runtime API when compiling untrusted code.** It hands that code
+the host platform and voids the guarantees the rest of this documentation
+describes.

--- a/lib/README.md
+++ b/lib/README.md
@@ -2,7 +2,8 @@
 
 Jo ships **four libraries**, and this bundle documents all of them. They are not
 peers: one is confined, and three are not. Which is which decides what a program
-built on them is able to do.
+built on them is able to do. Everything under `jo` except `jo.py`, `jo.rb` and
+`jo.js` is the standard library.
 
 <svg viewBox="0 0 760 360" role="img" width="100%"
      aria-label="A wall separates two worlds. On the green confined side sits the jo standard library, which has no FFI, no ambient authority and cannot originate an effect; confinement is transitive, so confined code may depend only on confined code. On the orange trusted side, the jo.py, jo.rb and jo.js runtime libraries reach the host platform: filesystem, network, processes and any module. The only opening in the wall is a gate through which capabilities pass into confined code at link time. A direct route from confined code to the host is blocked."
@@ -66,14 +67,16 @@ built on them is able to do.
         fill="currentColor" fill-opacity="0.7">a runtime library is reachable only under --use-runtime-api</text>
 </svg>
 
-## Stability
+## The four libraries
 
-| Library | Status |
-| --- | --- |
-| [`jo`](#/jo) — standard library | Stabilizing |
-| [`jo.py`](#/jo.py) — Python interop | Stabilizing |
-| [`jo.rb`](#/jo.rb) — Ruby interop | Experimental |
-| [`jo.js`](#/jo.js) — JavaScript interop | Experimental |
+The standard library spans five namespaces; each runtime API is a single one.
+
+| Library | Namespaces | Status |
+| --- | --- | --- |
+| Standard library | [`jo`](#/jo) · [`jo.mutable`](#/jo.mutable) · [`jo.regex`](#/jo.regex) · [`jo.resource`](#/jo.resource) · [`jo.compile`](#/jo.compile) | Stabilizing |
+| Python interop | [`jo.py`](#/jo.py) | Stabilizing |
+| Ruby interop | [`jo.rb`](#/jo.rb) | Experimental |
+| JavaScript interop | [`jo.js`](#/jo.js) | Experimental |
 
 *Stabilizing* means the shape is settling: breaking changes are not intended, but
 expect some to slip through. *Experimental* means the API may change at any time.

--- a/lib/compile.jo
+++ b/lib/compile.jo
@@ -1,7 +1,5 @@
 namespace jo.compile
 
-import jo.String
-
 //[ Vararg element type accepting positional args, splices, and keyword args.
   !
   ! Used as the element type of a vararg parameter to allow mixed calling

--- a/lib/mutable/List.jo
+++ b/lib/mutable/List.jo
@@ -1,7 +1,5 @@
 namespace jo.mutable
 
-import jo.*
-
 //[ Factory methods for `mutable.List`. //]
 section List
   //[ Number of slots a new list starts with, before it first grows. //]

--- a/lib/mutable/Map.jo
+++ b/lib/mutable/Map.jo
@@ -1,7 +1,5 @@
 namespace jo.mutable
 
-import jo.*
-
 //[ Factory methods for `mutable.Map`. //]
 section Map
   //[ Number of slots a new map starts with, before it first grows. //]

--- a/lib/mutable/Set.jo
+++ b/lib/mutable/Set.jo
@@ -1,7 +1,5 @@
 namespace jo.mutable
 
-import jo.*
-
 //[ Factory methods for `mutable.Set`. //]
 section Set
   //[ Number of slots a new set starts with, before it first grows. //]

--- a/lib/regex/Engine.jo
+++ b/lib/regex/Engine.jo
@@ -1,7 +1,5 @@
 namespace jo.regex
 
-import jo.*
-
 //[ The backend regular-expression engine behind `Regex`.
   !
   ! Application code uses `Regex`; this section is the seam the backends

--- a/lib/regex/Match.jo
+++ b/lib/regex/Match.jo
@@ -1,7 +1,5 @@
 namespace jo.regex
 
-import jo.*
-
 //[ One successful regular-expression match
   !
   ! `from` and `length` locate the match in the subject string; the group

--- a/lib/regex/Regex.jo
+++ b/lib/regex/Regex.jo
@@ -1,7 +1,5 @@
 namespace jo.regex
 
-import jo.*
-
 //[ Portable regular expression value.
   !
   ! Jo regexes intentionally support only a conservative common subset so the

--- a/lib/regex/Validator.jo
+++ b/lib/regex/Validator.jo
@@ -1,7 +1,5 @@
 namespace jo.regex
 
-import jo.*
-
 private def flagsPrefixLen(source: String): Int =
   if source.size < 4 || source[0] != '(' || source[1] != '?' then
     0

--- a/lib/resource/Resources.jo
+++ b/lib/resource/Resources.jo
@@ -1,7 +1,5 @@
 namespace jo.resource
 
-import jo.*
-
 //[ Metadata for one packaged resource file or directory.
   !
   ! `sizeBytes` is meaningful for files. Directories report `0`.

--- a/stack-lang/typing/Namer.scala
+++ b/stack-lang/typing/Namer.scala
@@ -41,11 +41,32 @@ class Namer(using Config) extends Applications with SelectionTyper:
   val exprTyper = new ExprTyper(this)
 
   def transform
-      (units: List[Ast.FileUnit], rootNameTable: NameTable, worldScope: Scope)
+      (units: List[Ast.FileUnit], rootNameTable: NameTable)
       (using defnLazy: Definitions.Lazy, rp: Reporter)
   : List[FileUnit] = Checks.delayed:
 
     given SymbolIndex = defnLazy.index
+
+    /** The prelude a file unit sits in: the root, with `jo` opened.
+      *
+      * This is what lets a nested namespace such as `jo.mutable` or `jo.py` see
+      * the standard library without importing it, however the stdlib reached
+      * this compilation -- loaded from `.sast` libraries, or compiled from
+      * source in this same run.
+      *
+      * It is built per unit rather than once up front because when the stdlib
+      * is itself being compiled, `jo` does not exist yet as this loop starts:
+      * `resolveNamespace` below is what creates it. Nothing reads a name
+      * through the prelude before then, since imports run in `delayedImports`
+      * and bodies in `delayedUnits`, both after every unit has been indexed.
+      * The prelude also holds `jo`'s name table by reference, so members
+      * registered later are still visible through it.
+      */
+    def prelude: Scope =
+      val root = new Scope.RootScope(rootNameTable, owner = null)
+      Definitions.resolveStatic(rootNameTable, List("jo"), SymbolKind.Container) match
+        case Some(joSym) => root.fresh(joSym, joSym.nameTable)
+        case None => root
 
     val delayedImports = new mutable.ArrayBuffer[() => Unit]
     val delayedUnits = new mutable.ArrayBuffer[(() => FileUnit, Source)]
@@ -57,7 +78,7 @@ class Namer(using Config) extends Applications with SelectionTyper:
       val memberTable = unitSym.nameTable
 
       // Default imports should be treated as just before normal imports
-      val importScope: Scope = worldScope.fresh(unitSym)
+      val importScope: Scope = prelude.fresh(unitSym)
       val defsScope: Scope = importScope.fresh(unitSym, memberTable)
 
       val delayedDefs =

--- a/stack-lang/typing/Typer.scala
+++ b/stack-lang/typing/Typer.scala
@@ -21,7 +21,6 @@ object Typer:
   : (List[FileUnit], pickle.LazyFileUnits) =
 
     val rootNameTable = defnLazy.rootNameTable
-    val rootScope = new Scope.RootScope(rootNameTable, owner = null)
 
     def checkPostTyping(units: List[FileUnit]): List[FileUnit] =
       given Definitions = defnLazy.value
@@ -51,7 +50,7 @@ object Typer:
 
     if libs.isEmpty then
       // compile stdlib to a lib
-      val units0 = new Namer().transform(unitsAst, rootNameTable, rootScope) <| "namer.source"
+      val units0 = new Namer().transform(unitsAst, rootNameTable) <| "namer.source"
       val units = if !rp.hasErrors then checkPostTyping(units0) else units0
 
       (units, new pickle.LazyFileUnits)
@@ -61,12 +60,7 @@ object Typer:
       val delayedUnits = new pickle.LazyFileUnits
       libs.foreach(lib => pickle.Decoder.loadPackage(lib, delayedUnits)) <| "load libs"
 
-      // Must be after loading the stdlib
-      val defn = defnLazy.value
-
-      val joScope = rootScope.fresh(defn.jo, defn.jo_nameTable)
-
-      val units0 = new Namer().transform(unitsAst, rootNameTable, joScope) <| "namer.source"
+      val units0 = new Namer().transform(unitsAst, rootNameTable) <| "namer.source"
       val units = if !rp.hasErrors then checkPostTyping(units0) else units0
 
       (units, delayedUnits)


### PR DESCRIPTION
Publish runtime docs

## Summary

- Publish runtime docs
- Auto import `jo.*` even with `--no-stdlib`

## Checklist

- [x] ~Added / updated tests under `tests/pos/` or `tests/warn/`~
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

No

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

