### PR TITLE
Release Jo 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.0] - 2026-08-25
+
+### Added
+
+- `--source-root <dir>` records source paths relative to `<dir>` in `.sast`
+  files and generated documentation, so absolute build paths stay out of
+  published artifacts. A file outside the root is recorded by name only. `jo
+  build` defaults it to the module's project directory. ([#94])
+- The `jo.py`, `jo.rb` and `jo.js` runtime FFI APIs are published together with
+  the standard library documentation, and each library lists its namespaces on
+  the home page. ([#100])
+- Annotations appear as their own kind in the generated documentation, with a
+  badge in the UI, and doc comments now attach to annotation declarations.
+  ([#100])
+
+### Changed
+
+- Optional context parameters are dropped. A declaration that carries a default,
+  `param pageWidth: Int = 80`, is no longer accepted. A declaration now states
+  only the requirement and the caller provides the value with `with pageWidth =
+  80 in render(document)`. `with`, `receives`, `allow`, shadowing and capture
+  keep their current meaning. See [JIP-0002] for the rationale. ([#95])
+- `jo.*` is opened for every unit however the standard library arrived.
+  `--no-stdlib` selects where the library comes from and no longer suppresses
+  the automatic import. ([#100])
+- The `jo.IO` capabilities are documented as capabilities and moved into a
+  `section IO` of namespace `jo`. The paths `IO.stdout`, `IO.stderr` and
+  `IO.args` are unchanged. ([#100])
+
+### Removed
+
+- `IO.stdin`, and with it the standard input capability. A program that reads
+  input obtains it from a backend-specific API such as `py.input` and passes it
+  on as its own context parameter. `jo.main` correspondingly receives
+  `IO.stdout`, `IO.stderr` and `IO.args`. ([#100])
+
+### Fixed
+
+- Private sections are kept out of the generated documentation. ([#100])
+- Empty namespaces are hidden in the documentation navigation list. ([#100])
+
+### Security
+
+- Dropping optional context parameters closes a capability hole. A default
+  satisfied a requirement silently, so `allow none in e` denied `e` only the
+  ambient context that lacked a default rather than all of it, and a `receives
+  none` body could keep reading a parameter pinned to its declared value with
+  nothing to notice at the call site. Every context parameter is now supplied by
+  an explicit binding and is subject to `allow`. ([#95])
+- `--source-root` keeps absolute filesystem paths out of `.sast` files and
+  generated documentation. ([#94])
+
+### Compatibility
+
+- This release is source-breaking. Code that declares an optional context
+  parameter no longer compiles. Give the declaration no default and bind it at
+  the call site with `with`. ([#95])
+- Libraries must be recompiled. `.sast` files produced by earlier compilers are
+  not loadable by this release. Files produced by this release remain loadable
+  by earlier compilers. ([#95])
+- Code that uses `IO.stdin` no longer compiles, and a custom entry point that
+  declares `receives IO.stdin` must drop it. ([#100])
+- No build-spec changes are required. `--source-root` is optional, and artifacts
+  generated without it record paths as before. ([#94])
+
+[#94]: https://github.com/typescope/jo/pull/94
+[#95]: https://github.com/typescope/jo/pull/95
+[#100]: https://github.com/typescope/jo/pull/100
+[JIP-0002]: https://jo-lang.org/jips/0002-drop-optional-context-params
+
 ## [0.12.5] - 2026-08-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.12.5-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.12.5)
+  [![Release](https://img.shields.io/badge/release-v0.13.0-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.13.0)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -11,3 +11,4 @@
 {"version":"0.12.3","url":"https://github.com/typescope/jo/releases/download/v0.12.3/jo-0.12.3.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.3/jo-0.12.3.tar.gz.sha256","date":"2026-08-03"}
 {"version":"0.12.4","url":"https://github.com/typescope/jo/releases/download/v0.12.4/jo-0.12.4.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.4/jo-0.12.4.tar.gz.sha256","date":"2026-08-05"}
 {"version":"0.12.5","url":"https://github.com/typescope/jo/releases/download/v0.12.5/jo-0.12.5.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.5/jo-0.12.5.tar.gz.sha256","date":"2026-08-22"}
+{"version":"0.13.0","url":"https://github.com/typescope/jo/releases/download/v0.13.0/jo-0.13.0.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.13.0/jo-0.13.0.tar.gz.sha256","date":"2026-08-25"}

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 12, 5)
+  val current: Version = Version(0, 13, 0)


### PR DESCRIPTION
Release Jo 0.13.0

## Summary

Cuts the 0.13.0 release. Release-metadata only, no compiler or library code is
touched. A minor bump rather than a patch because the release is
source-breaking: optional context parameters are dropped ([#95], [JIP-0002])
and `IO.stdin` is removed ([#100]).

## What has changed

- `stack-lang/tool/JoVersion.scala` — version bumped to `0.13.0`, verified with
  `bin/jo.dev --version`
- `README.md` — release badge and tag link updated to `v0.13.0`
- `CHANGELOG.md` — 0.13.0 section covering [#94], [#95] and [#100], with the
  security and compatibility sections
- `docs/public/versions.jsonl` — entry appended for `v0.13.0`

## Checklist

- [x] ~Added / updated tests under `tests/pos/` or `tests/warn/`~ — release metadata only
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

## Security impact

No change in this PR. The release itself carries two security-relevant changes,
both recorded in the changelog:

- Dropping optional context parameters closes a capability hole. A default
  satisfied a requirement silently, so `allow none in e` denied `e` only the
  ambient context that lacked a default rather than all of it. ([#95])
- `--source-root` keeps absolute filesystem paths out of `.sast` files and
  generated documentation. ([#94])

## Compatibility impact

No change in this PR. The release is source-breaking, as recorded in the
changelog. The boxes below describe the 0.13.0 release as a whole, and match
what [#95] and [#100] reported when they merged.

- [ ] ~Source compatibility: existing code continue to compile~ — optional context parameter declarations and uses of `IO.stdin` no longer compile
- [ ] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [ ] ~backward comopatibility: old libraries can be used by new compiler~ — libraries must be recompiled if they use optional context parameters
- [ ] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [ ] ~backward compatibility: old code work with the new stdlib~ — `IO.stdin` is removed
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

[#94]: https://github.com/typescope/jo/pull/94
[#95]: https://github.com/typescope/jo/pull/95
[#100]: https://github.com/typescope/jo/pull/100
[JIP-0002]: https://jo-lang.org/jips/0002-drop-optional-context-params
