### PR TITLE
Support getting source location

### DIFF
--- a/docs/language/definitions/autos.md
+++ b/docs/language/definitions/autos.md
@@ -64,7 +64,27 @@ For each omitted auto argument of type `T` with candidate list `[c1, ..., cn]`:
 1. **Local scope:** Search for an `auto` definition or `auto` parameter of type `T` in the enclosing scope. Innermost definition wins. If found, use it and stop.
 2. **Candidates:** Try `c1, c2, ...` in order. The first that conforms to `T` (or whose eta-expansion conforms to `T`) is used. When a matching candidate itself has auto parameters, they are resolved recursively by the same algorithm.
 3. **Identity synthesis:** If `T` is a function type `U => V` with `U <: V`, synthesize the identity function `(x: U) => x`.
-4. **Failure:** Report an error with the full search tree.
+4. **Source-location synthesis:** If `T` is the standard-library type `jo.compile.SourceLocation`, synthesize a value containing the compiler-published path and 1-based line number of the call expression. This rule applies only to that canonical type, not to another type with the same name.
+5. **Failure:** Report an error with the full search tree.
+
+Local-scope lookup happens before source-location synthesis. A helper that already
+has an auto `SourceLocation` therefore forwards it to nested calls, preserving the
+location where the outermost helper was called:
+
+```jo
+import jo.compile.SourceLocation
+
+def fail(message: String)(auto location: SourceLocation): Unit =
+  abort(location.file + ":" + location.line.toString + ": " + message)
+
+def check(cond: Bool)(auto location: SourceLocation): Unit =
+  if !cond then fail("check failed") // forwards location
+
+check(answer == 42) // synthesis occurs here
+```
+
+The synthesized file is relative to `--source-root` when the source is beneath
+that root. For a source outside the root, only its filename is published.
 
 ```jo
 def process[T](x: T)(auto eq: Eq[T] with [eqInt, eqString, [T].==]): Unit = ...

--- a/lib/compile.jo
+++ b/lib/compile.jo
@@ -2,8 +2,27 @@ namespace jo.compile
 
 //[ The compiler-published source path and 1-based line number of a call.
   !
-  ! A value is synthesized when a function requires an automatic
-  ! `SourceLocation` and no local automatic value of this type is available.
+  ! A value is synthesized when a function requires an auto
+  ! `SourceLocation` and no local auto value of this type is available.
+  ! Declare it in a function's auto parameter block:
+  !
+  !     import jo.compile.SourceLocation
+  !
+  !     def check(cond: Bool)(auto location: SourceLocation): Unit =
+  !       if !cond then
+  !         abort(location.file + ":" + location.line.toString + ": check failed")
+  !
+  !     check(answer == 42)
+  !
+  ! The call to `check` receives the source path and line of the call expression.
+  ! If a function with a `SourceLocation` parameter calls another such function,
+  ! normal auto resolution forwards the existing value. This
+  ! preserves the location of the outermost call rather than reporting a line
+  ! inside a test helper.
+  !
+  ! `file` is the portable path published by the compiler. A source below
+  ! `--source-root` is recorded relative to that root; a source outside the root
+  ! is reduced to its filename. `line` is 1-based.
 //]
 class SourceLocation(file: String, line: Int)
 

--- a/lib/compile.jo
+++ b/lib/compile.jo
@@ -1,5 +1,12 @@
 namespace jo.compile
 
+//[ The compiler-published source path and 1-based line number of a call.
+  !
+  ! A value is synthesized when a function requires an automatic
+  ! `SourceLocation` and no local automatic value of this type is available.
+//]
+class SourceLocation(file: String, line: Int)
+
 //[ Vararg element type accepting positional args, splices, and keyword args.
   !
   ! Used as the element type of a vararg parameter to allow mixed calling

--- a/stack-lang/sast/Adaptation.scala
+++ b/stack-lang/sast/Adaptation.scala
@@ -6,6 +6,7 @@ import sast.Symbols.*
 
 import ast.Positions.{Span, Source}
 import common.Debug
+import reporting.Config
 
 
 object Adaptation:
@@ -77,7 +78,7 @@ object Adaptation:
     *
     */
   def adapt(word: Word, targetType: Type, adapters: List[Adapter])
-      (using defn: Definitions)
+      (using defn: Definitions, config: Config)
   : Word = Debug.trace(s"adapting ${word.show} to ${targetType.show}", enable = false):
 
     assert(targetType.isFullyInstantiated, "not fully instantiated: " + targetType.show)
@@ -277,7 +278,7 @@ object Adaptation:
     Adapter.VarargSplice(adapters, owner, scope, source) :: Nil
 
   private def adaptWithAdapters(word: Word, targetType: Type, adapters: List[Adapter])
-      (using defn: Definitions)
+      (using defn: Definitions, config: Config)
   : Result =
     val trials = new scala.collection.mutable.ArrayBuffer[Trial]()
     var success: Option[Word] = None
@@ -317,7 +318,7 @@ object Adaptation:
 
   def adaptSimple
       (word: Word, targetType: Type, adapters: List[ParamAdapter], owner: Symbol, scope: typing.Scope)
-      (using Definitions, Source)
+      (using Definitions, Source, Config)
   : Result = Debug.trace(s"adapt ${word.show} to ${targetType.show} with ${adapters}", enable = false):
     val trials = new scala.collection.mutable.ArrayBuffer[Trial]()
     var remaining = adapters
@@ -420,7 +421,7 @@ object Adaptation:
 
   def adaptVarargSplice
       (word: Word, targetElemType: Type, elemType: Type, adapters: List[ParamAdapter], owner: Symbol, scope: typing.Scope)
-      (using Definitions, Source)
+      (using Definitions, Source, Config)
   : Result = Debug.trace(s"adapt splice ${word.show} from ${elemType.show} to ${targetElemType.show} with ${adapters}", enable = false):
     val trials = new scala.collection.mutable.ArrayBuffer[Trial]()
     var remaining = adapters
@@ -514,7 +515,7 @@ object Adaptation:
     */
   private def createMemberAccessor
       (memberName: String, paramType: Type, memberType: Type, resultType: Type, owner: Symbol, scope: typing.Scope, span: Span)
-      (using Definitions, Source)
+      (using Definitions, Source, Config)
   : Either[AutoResolution.SearchNode.All, Word] =
     // Build the lambda type for the lambda
     val lambdaType = LambdaType(

--- a/stack-lang/sast/AutoResolution.scala
+++ b/stack-lang/sast/AutoResolution.scala
@@ -5,6 +5,7 @@ import Trees.*
 import Symbols.*
 
 import ast.Positions.*
+import reporting.Config
 
 import scala.collection.mutable
 
@@ -49,7 +50,7 @@ object AutoResolution:
     case Success
 
   def resolve(procType: ProcType, localAutos: List[Symbol], trace: Vector[TraceElement], all: SearchNode.All, owner: Symbol, span: Span)
-      (using Definitions, Source)
+      (using Definitions, Source, Config)
   : Option[List[Word]] =
 
     val autos = new mutable.ArrayBuffer[Word]
@@ -87,7 +88,7 @@ object AutoResolution:
   def search
       (targetType: Type, cands: List[Symbol | MemberCandidate], localAutos: List[Symbol],
         trace: Vector[TraceElement], choice: SearchNode.Choice, owner: Symbol, span: Span)
-      (using defn: Definitions, source: Source)
+      (using defn: Definitions, source: Source, config: Config)
   : Option[Word] =
 
     // First, search local autos
@@ -117,10 +118,11 @@ object AutoResolution:
 
     // Last resort: try identity
     trySynthesizeIdentity(targetType, choice, owner, span)
+      .orElse(trySynthesizeSourceLocation(targetType, span))
 
   def tryValue
       (sym: Symbol, targetType: Type, trace: Vector[TraceElement], trial: SearchNode.Trial, owner: Symbol, localAutos: List[Symbol], span: Span)
-      (using Definitions, Source)
+      (using Definitions, Source, Config)
   : Option[Word] =
 
     val tp = sym.tpe
@@ -173,7 +175,7 @@ object AutoResolution:
   def tryMember
       (receiverType: Type, name: String, targetType: Type, trace: Vector[TraceElement],
         trial: SearchNode.Trial, owner: Symbol, localAutos: List[Symbol], span: Span)
-      (using defn: Definitions, so: Source)
+      (using defn: Definitions, so: Source, config: Config)
   : Option[Word] =
 
     // Check for cycles: if this member candidate is already in trace, we have divergence
@@ -244,7 +246,7 @@ object AutoResolution:
   def tryMethodMember
       (procType: ProcType, receiverType: Type, memberName: String, targetLambda: LambdaType,
         trace: Vector[TraceElement], trial: SearchNode.Trial, owner: Symbol, localAutos: List[Symbol], span: Span)
-      (using defn: Definitions, so: Source)
+      (using defn: Definitions, so: Source, config: Config)
   : Option[Word] =
     val lambdaParamTypes = receiverType :: procType.paramTypes
 
@@ -297,7 +299,7 @@ object AutoResolution:
   def tryExtensionMember
       (sym: Symbol, receiverType: Type, memberName: String, targetLambda: LambdaType,
         trace: Vector[TraceElement], trial: SearchNode.Trial, owner: Symbol, localAutos: List[Symbol], span: Span)
-      (using defn: Definitions, so: Source)
+      (using defn: Definitions, so: Source, config: Config)
   : Option[Word] =
     val procType = sym.tpe.asProcType
 
@@ -416,6 +418,16 @@ object AutoResolution:
         case res => res
     else
       Some(lambda)
+
+  private def trySynthesizeSourceLocation(targetType: Type, span: Span)(using defn: Definitions, source: Source, config: Config): Option[Word] =
+    if !Subtyping.isEqualType(targetType, StaticRef(defn.SourceLocation_class)) then return None
+
+    val newLocation = New(TypeTree(targetType)(span.point))(span.point)
+    val constructor = newLocation.select(Names.Constructor)
+    Some(constructor.appliedTo(
+      StringLit(Config.publishedSourcePath(source.file))(span.point),
+      IntLit(span.toPos.startLine + 1)(span.point),
+    ))
 
   /** Format search tree as error message */
   def formatSearchTree(all: AutoResolution.SearchNode.All, baseIndent: String = "")(using Definitions): String =

--- a/stack-lang/sast/Definitions.scala
+++ b/stack-lang/sast/Definitions.scala
@@ -80,6 +80,7 @@ final class Definitions(private var _index: SymbolIndex) extends Definitions.Laz
 
   // Compile utilities
   val compile          = resolveContainer("jo.compile")
+  val SourceLocation_class = compile.typeMember("SourceLocation")
   val Mixed_type       = compile.typeMember("Mixed")
   val Named_type       = compile.typeMember("Named")
   val compile_namedArg = compile.termMember("namedArg")

--- a/stack-lang/sast/Trees.scala
+++ b/stack-lang/sast/Trees.scala
@@ -735,16 +735,15 @@ object Trees:
       assert(procType.tparams.isEmpty, "type params not supplied")
       assert(procType.autos.isEmpty, "autos not supplied")
 
-      val args2 =
-        for
-          (arg, paramType) <- args.zip(procType.paramTypes)
-        yield
-          // Both fun and arg are fully instantiated
-          Adaptation.adapt(arg, paramType, Nil)
+      for (arg, paramType) <- args.zip(procType.paramTypes) do
+        assert(
+          Subtyping.conforms(arg.tpe, paramType),
+          s"argument type ${arg.tpe.show} does not conform to parameter type ${paramType.show} in ${word.show}",
+        )
 
       val span = args.foldLeft(word.span)(_ | _.span)
 
-      Apply(word, args2.toList, autos = Nil)(span)
+      Apply(word, args.toList, autos = Nil)(span)
 
     def appliedToTypes(targs: Type*)(using Definitions): Word =
       val targList = targs.toList

--- a/stack-lang/typing/Applications.scala
+++ b/stack-lang/typing/Applications.scala
@@ -161,7 +161,7 @@ trait Applications extends DynamicTyper:
           if invokeType.autoTypes.isEmpty then
             TreeOps.smartApply(fun1, argsTyped, autos = Nil)(applySpan).adapt
           else
-            Autos.resolve(fun1, argsTyped, applySpan).adapt
+            Autos.resolve(fun1, argsTyped, applySpan, config).adapt
 
     else
       if !fun1.tpe.isError then
@@ -206,7 +206,7 @@ trait Applications extends DynamicTyper:
     else
       val paramType = procType.paramTypes.head
       val argTyped = transformArg(arg, paramType)
-      Autos.resolve(fun, argTyped :: Nil, call.span).adapt
+      Autos.resolve(fun, argTyped :: Nil, call.span, config).adapt
 
   /** Handles infix call formed by expression typer `1 + 2` */
   def transformInfixCall(call: Ast.InfixCall)
@@ -258,7 +258,7 @@ trait Applications extends DynamicTyper:
           transformArgs(postArgs, procType.postParamTypes)
 
 
-      Autos.resolve(fun, preArgs2 ++ postArgs2, call.span).adapt
+      Autos.resolve(fun, preArgs2 ++ postArgs2, call.span, config).adapt
 
   /** Assumes that the argument count requirement is satisfied */
   def transformArgs

--- a/stack-lang/typing/Autos.scala
+++ b/stack-lang/typing/Autos.scala
@@ -9,6 +9,7 @@ import sast.Types.*
 import sast.Symbols.*
 
 import reporting.Reporter
+import reporting.Config
 
 import scala.collection.mutable
 
@@ -147,7 +148,7 @@ object Autos:
       i += 1
     end while
 
-  def resolve(fun: Word, args: List[Word], span: Span)
+  def resolve(fun: Word, args: List[Word], span: Span, config: Config)
       (using defn: Definitions, source: Source, rp: Reporter, sc: Scope)
   : Word =
     val procType: ProcType = fun.tpe.asProcType
@@ -178,8 +179,9 @@ object Autos:
 
     val all = new AutoResolution.SearchNode.All(new mutable.ArrayBuffer)
     val localAutos = sc.collectLocalAutos
+    given Config = config
 
-    AutoResolution.resolve(procType, localAutos, Vector.empty[AutoResolution.TraceElement], all, sc.owner, span.endPoint) match
+    AutoResolution.resolve(procType, localAutos, Vector.empty[AutoResolution.TraceElement], all, sc.owner, span) match
       case Some(autos) =>
         TreeOps.smartApply(fun, args, autos)(span)
 

--- a/stack-lang/typing/Checker.scala
+++ b/stack-lang/typing/Checker.scala
@@ -271,7 +271,7 @@ object Checker:
         Reporter.error(s"Cannot find common result type, tp1 = ${tp1.show}, tp2 = ${tp2.show}", pos)
         ErrorType
 
-  def adaptParameterless(word: Word, targetType: TargetType)(using Definitions, Scope, Reporter, Source, TypeVars): Word =
+  def adaptParameterless(word: Word, targetType: TargetType)(using Definitions, Scope, Reporter, Source, TypeVars, Config): Word =
     if !word.tpe.isProcType then return word
 
     val procType = word.tpe.asProcType
@@ -298,13 +298,13 @@ object Checker:
       // Constrain result type
       Inference.conditionalInstantiate(resType, targetType)
 
-      Autos.resolve(fun, Nil, word.span)
+      Autos.resolve(fun, Nil, word.span, summon[Config])
 
     else
       word
 
   def adapt(word: Word, targetType: TargetType)
-      (using defn: Definitions, sc: Scope, rp: Reporter, so: Source, tvars: TypeVars)
+      (using defn: Definitions, sc: Scope, rp: Reporter, so: Source, tvars: TypeVars, config: Config)
   : Word = Debug.trace("Adapting " + word.show + ", tt = " + targetType.show, (_: Word).show, enable = false):
     val defn = summon[Definitions]
 

--- a/stack-lang/typing/FlowTyper.scala
+++ b/stack-lang/typing/FlowTyper.scala
@@ -10,6 +10,7 @@ import common.OutOfBand
 import sast.*
 import sast.Trees.*
 import reporting.Reporter
+import reporting.Config
 
 import Inference.TargetType
 
@@ -21,9 +22,10 @@ import scala.collection.mutable
   */
 object FlowTyper:
   extension (word: Word)
-    def adapt(using tt: TargetType, defn: Definitions, sc: FlowScope, rp: Reporter, so: Source, tvars: TypeVars): Word =
+    def adapt(config: Config)(using tt: TargetType, defn: Definitions, sc: FlowScope, rp: Reporter, so: Source, tvars: TypeVars): Word =
       // adaptation should not need flow scope
       given Scope = sc.outer
+      given Config = config
       Checker.adapt(word, tt)
 
   def transformFlow(word: Ast.Word, namer: Namer)
@@ -147,7 +149,7 @@ object FlowTyper:
       // `!` does not change bound variables
       sc.resetPromotedSet(snapShot)
 
-      rhsTyped.select(Names.PrefixNot).adapt
+      rhsTyped.select(Names.PrefixNot).adapt(namer.config)
 
     else
       val prefixOperatorMethod = Naming.prefixOperatorMethod(op.name)
@@ -156,7 +158,7 @@ object FlowTyper:
           tp match
             case ref: Types.RefType => Checker.checkAccess(ref.symbol, sc.owner, call.span)
             case _ =>
-          TreeOps.smartSelect(rhsTyped, prefixOperatorMethod, call.span).adapt
+          TreeOps.smartSelect(rhsTyped, prefixOperatorMethod, call.span).adapt(namer.config)
 
         case _ =>
           // Typing operator using outer scope
@@ -177,7 +179,7 @@ object FlowTyper:
 
           given Scope = sc.fresh()
           val infixCall = Ast.InfixCall(Nil, op, rhs :: Nil)(call.span)
-          namer.transformInfixCall(infixCall).adapt
+          namer.transformInfixCall(infixCall).adapt(namer.config)
 
   def transformInfixOperatorCall(call: Ast.InfixOperatorCall, namer: Namer)
       (using defn: Definitions, sc: FlowScope, rp: Reporter, so: Source, tt: TargetType, tvars: TypeVars, cs: ControlScope)
@@ -204,7 +206,7 @@ object FlowTyper:
         given TargetType = TargetType.Known(defn.BoolType)
         transformFlow(rhs, namer)
 
-      lhsTyped.select(op.name).appliedTo(rhsTyped).adapt
+      lhsTyped.select(op.name).appliedTo(rhsTyped).adapt(namer.config)
 
     else if tp.isBoolType && op.name == "||" then
       // `||` must bind the same set of variables for both branches
@@ -218,7 +220,7 @@ object FlowTyper:
       val setRHS = sc.promotedSet() -- snapShot
       for sym <- setRHS if !setLHS.contains(sym) do sc.demote(sym)
 
-      lhsTyped.select(op.name).appliedTo(rhsTyped).adapt
+      lhsTyped.select(op.name).appliedTo(rhsTyped).adapt(namer.config)
 
     else
       val isDotlessMethodCall = tp.isValueType && {
@@ -250,7 +252,7 @@ object FlowTyper:
 
       given Scope = sc.fresh()
       val infixCall = Ast.InfixCall(lhs :: Nil, op, rhs :: Nil)(call.span)
-      namer.transformInfixCall(infixCall).adapt
+      namer.transformInfixCall(infixCall).adapt(namer.config)
 
   /** Form AST from the words with the limit precedence for precedence expression
     *

--- a/stack-lang/typing/Namer.scala
+++ b/stack-lang/typing/Namer.scala
@@ -36,7 +36,7 @@ import scala.collection.mutable
   * It is important to NOT trigger effect inference and effect check during type
   * checking.
   */
-class Namer(using Config) extends Applications with SelectionTyper:
+class Namer(using val config: Config) extends Applications with SelectionTyper:
   val patternTyper = PatternTyper(this)
   val exprTyper = new ExprTyper(this)
 

--- a/tests/pos/source-location-auto.jo
+++ b/tests/pos/source-location-auto.jo
@@ -1,0 +1,35 @@
+import jo.compile.SourceLocation
+
+def location()(auto source: SourceLocation): SourceLocation = source
+
+def forwarded()(auto source: SourceLocation): SourceLocation =
+  location()
+
+type Formatter[T] = T => String
+
+def formatInt(value: Int): String = value.toString
+
+def intFormatter: Formatter[Int] = value => formatInt(value)
+
+def describe(value: Int)(
+    auto formatter: Formatter[Int] with [intFormatter],
+         source: SourceLocation
+): String =
+  formatter(value) + "@" + source.file + ":" + source.line.toString
+
+def main: Unit =
+  val direct = location()
+  println direct.file
+  println direct.line
+
+  val propagated = forwarded()
+  println propagated.file
+  println propagated.line
+
+  val combined = describe(42)
+  println combined
+
+  auto overridden: SourceLocation = new SourceLocation("generated.jo", 99)
+  val explicit = location()
+  println explicit.file
+  println explicit.line

--- a/tests/pos/source-location-auto.jo.check
+++ b/tests/pos/source-location-auto.jo.check
@@ -1,0 +1,7 @@
+tests/pos/source-location-auto.jo
+21
+tests/pos/source-location-auto.jo
+25
+42@tests/pos/source-location-auto.jo:29
+generated.jo
+99


### PR DESCRIPTION
Support getting source location

## Summary

<!-- What does this PR do and why? -->

Support getting source and line positions to support testing and debugging:

```
import jo.compile.SourceLocation

def check(cond: Bool)(auto location: SourceLocation): Unit =
  if !cond then
    abort(location.file + ":" + location.line.toString + ": check failed")

check(answer == 42)
```

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

Code that depend on the new API cannot use old standard library.

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [ ] ~forward compatibility: new code can work with old stdlib~
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

