### PR TITLE
Fix doc tool

### DIFF
--- a/docs/blog/2026-08-22-standard-library-docs.md
+++ b/docs/blog/2026-08-22-standard-library-docs.md
@@ -51,14 +51,13 @@ documents your project:
 jo doc
 ```
 
-It reads settings from `jo.toml` and writes a self-contained directory to
+It reads the selected module's `doc-options` from `jo.toml` and writes a self-contained directory to
 `.build/<module>/doc/` — no web server, no build step, open `index.html` in a
 browser:
 
 ```toml
-[doc]
-title = "Agent API"
-readme = "README.md"
+[module.api]
+doc-options = ["--title", "Agent API", "--readme", "README.md"]
 ```
 
 The version shown beside the title in the header comes from your module's

--- a/docs/usage/commands/compile.md
+++ b/docs/usage/commands/compile.md
@@ -14,7 +14,7 @@ jo compile --python|--ruby|--js [--sast <dir>] [--source-root <dir>] <file.jo>..
 
 # Generate HTML documentation from source files (experimental)
 jo compile --doc [--out <dir>] [--title <name>] [--readme <file>] \
-           [--include-private] [--include-source] [--source-root <dir>] \
+           [--include-private] [--source-root <dir>] \
            <file.jo>...
 
 # Query API information as JSON (experimental)
@@ -50,7 +50,8 @@ the file and report diagnostics.
 
 Project commands such as `jo build` and `jo doc` default the source root to the
 module's project directory. An explicit `--source-root` in the module's
-`compile-options` overrides that default.
+`compile-options` overrides that default for compilation; put it in
+`doc-options` to override the documentation default.
 
 ### Documentation
 
@@ -64,7 +65,6 @@ Experimental.
 | `--project-version <version>` | Version shown beside the title. Omitted: the header reads `version unknown` |
 | `--readme <file>` | Markdown file to use as the generated documentation home page |
 | `--include-private` | Include private symbols |
-| `--include-source` | Embed source code in output |
 
 ### Query
 

--- a/docs/usage/commands/doc.md
+++ b/docs/usage/commands/doc.md
@@ -15,22 +15,22 @@ If `module` is omitted, Jo documents the project default module.
 Generated HTML files are written to `.build/<module>/doc/`.
 On success, `jo doc` prints that output directory.
 
-`jo doc` uses the selected module's sources and reads documentation settings from `jo.toml`:
+`jo doc` uses the selected module's sources and reads `doc-options` from `jo.toml`:
 
 ```toml
-[doc]
-title = "Agent API"
-readme = "README.md"
-include-private = false
-include-source = false
+[module.api]
+kind = "lib"
+src = ["src/"]
+doc-options = [
+  "--title", "Agent API",
+  "--readme", "README.md",
+]
 ```
 
-| Field             | Description                                                  |
-|-------------------|--------------------------------------------------------------|
-| `title`           | Project title shown in the documentation header.             |
-| `readme`          | Markdown file used as the home page. Optional.               |
-| `include-private` | Include private symbols. Default: `false`.                   |
-| `include-source`  | Embed source locations. Default: `false`.                    |
+The options are passed verbatim to `jo compile --doc`. They apply only to
+documentation generation; the module's `compile-options` do not apply to
+`jo doc`. See the [compiler options reference](../reference/compiler-options.md#documentation-options)
+for available documentation options.
 
 The documentation header shows the module's version, taken from
 `[module.<id>.package].version`. Modules that declare no package show

--- a/docs/usage/reference/build-spec.md
+++ b/docs/usage/reference/build-spec.md
@@ -77,7 +77,8 @@ and may contain only ASCII letters, digits, and hyphens.
 | `platform`        | string           | app only | Platform this module is bound to. Apps: `"python"` or `"ruby"`, required. Libs: `"pure"`, `"python"`, or `"ruby"`, default `"pure"`. |
 | `enable-ffi`      | boolean          | no       | May this module's own code call the platform's FFI API (`py.*`, `rb.*`). Default: `false`. |
 | `depth`           | integer          | no       | Maximum registry package dependency depth for this module. Default: `0` for `lib`, `1` for `app`. |
-| `compile-options` | array of strings | no       | Extra flags passed verbatim to `jo compile` for this module. |
+| `compile-options` | array of strings | no       | Extra flags passed verbatim to normal compilation for this module. Not used by `jo doc`. |
+| `doc-options`     | array of strings | no       | Extra flags passed verbatim to `jo compile --doc` for this module. |
 | `modules`         | array            | no       | Source module dependencies. Strings, or tables with `id`. |
 | `packages`        | array of tables  | no       | Registry package dependencies. |
 | `links`           | array of tables  | app only | Explicit `defer def` wiring. Invalid on lib modules. |
@@ -306,18 +307,6 @@ version = "1.2.0"
 The package table has no `platform` of its own. Generated `meta.toml` takes it from the module, so there is one place to state it and it cannot drift from what was compiled.
 
 When packaging, direct registry dependencies are recorded in `meta.toml`. Direct source module dependencies are recorded by their package name and version line, unless `link = true`.
-
-## `[doc]`
-
-Documentation settings apply to `jo doc <module>`.
-
-```toml
-[doc]
-title = "Agent API"
-readme = "README.md"
-include-private = false
-include-source = false
-```
 
 ## `[commands]`
 

--- a/docs/usage/reference/compiler-options.md
+++ b/docs/usage/reference/compiler-options.md
@@ -2,7 +2,8 @@
 
 These are the low-level options accepted by `jo compile`. Project commands such as
 `jo build`, `jo check`, and `jo run` usually derive compiler flags from
-`jo.toml`, but `module.<id>.compile-options` can pass extra flags through to `jo compile`.
+`jo.toml`, but `module.<id>.compile-options` can pass extra flags through to normal
+compilation and `module.<id>.doc-options` can pass flags to `jo compile --doc`.
 
 For the command-level interface and examples, see [`jo compile`](../commands/compile.md).
 
@@ -100,7 +101,6 @@ above plus these documentation-specific options.
 | `--title <name>` | single value | Documentation title. Default: `API Documentation`. |
 | `--readme <file>` | single value | Markdown file to use as the generated documentation home page. |
 | `--include-private` | flag | Include private symbols. |
-| `--include-source` | flag | Embed source code in the generated documentation. |
 
 Documentation output is always HTML.
 

--- a/stack-lang/cli/Main.scala
+++ b/stack-lang/cli/Main.scala
@@ -328,5 +328,4 @@ object Main:
       |  --out <dir>           Output directory (default: docs)
       |  --title <name>        Project title for documentation
       |  --include-private     Include private symbols
-      |  --include-source      Embed source code in output
       |""".stripMargin)

--- a/stack-lang/doc/Compiler.scala
+++ b/stack-lang/doc/Compiler.scala
@@ -17,10 +17,9 @@ object Compiler:
   val projectVersion: Config.StringSetting = Config.StringSetting("--project-version", "", "project version shown in the header")
   val readme: Config.StringSetting = Config.StringSetting("--readme", "", "markdown file to use as home page")
   val includePrivate: Config.BooleanSetting = Config.BooleanSetting("--include-private", false, "include private symbols")
-  val includeSource: Config.BooleanSetting = Config.BooleanSetting("--include-source", false, "embed source code")
 
   val docOptions: List[cli.OptionParser.Setting[?]] =
-    outputDir :: title :: projectVersion :: readme :: includePrivate :: includeSource :: Config.commonOptions
+    outputDir :: title :: projectVersion :: readme :: includePrivate :: Config.commonOptions
 
   def main(args: Array[String]): Unit =
     given Reporter = Reporter.createReporter()
@@ -37,7 +36,6 @@ object Compiler:
       println("  --title <name>         Project title for documentation")
       println("  --project-version <v>  Project version shown in the header")
       println("  --include-private      Include private symbols")
-      println("  --include-source       Embed source code in output")
       println()
       println("Examples:")
       println("  jo doc lib/Core.jo lib/List.jo --out site/api")

--- a/stack-lang/query/Query.scala
+++ b/stack-lang/query/Query.scala
@@ -165,7 +165,9 @@ object Query:
     for sym <- filter.symbols do
       val matchedByAncestor =
         sym.ownersIterator.exists(matched.contains)
-      if !matched.contains(sym) && !matchedByAncestor then
+      val matchedBySameName =
+        matched.exists(_.fullName == sym.fullName)
+      if !matched.contains(sym) && !matchedByAncestor && !matchedBySameName then
         Reporter.error(s"No documentation entries match symbol selector `${sym.fullName}`")
 
     distinctUnits(trimmed)

--- a/stack-lang/tool/Build.scala
+++ b/stack-lang/tool/Build.scala
@@ -35,25 +35,27 @@ object Build:
       case e: IOException => Result.Err(s"error: ${e.getMessage}")
 
   def buildDoc(project: Project, module: ModuleId)(using Logger, PackageProvider): Result[Unit] =
-    makePlanResult(project, List(module)).flatMap: plans =>
-      val plan = plans.modules.head
-      val outDir = project.buildDir(module).resolve("doc")
-      val withDoc = plan.copy(
-        task = plan.task match
-          case lib: CompileTask.LibTask =>
-            lib.copy(compileOptions = lib.compileOptions ++ docOptions(project, module))
+    project.requireModule(module).flatMap: spec =>
+      makePlanResult(project, List(module)).flatMap: plans =>
+        val plan = plans.modules.head
+        val outDir = project.buildDir(module).resolve("doc")
+        val options = Planner.ffiCompileOptions(spec) ++ docOptions(project, module, spec.docOptions) ++ spec.docOptions
+        val withDoc = plan.copy(
+          task = plan.task match
+            case lib: CompileTask.LibTask =>
+              lib.copy(compileOptions = options)
 
-          case app: CompileTask.AppTask =>
-            CompileTask.LibTask(
-              app.sources,
-              app.checkLibs,
-              app.sastDir,
-              app.defaultSourceRoot,
-              app.compileOptions ++ docOptions(project, module),
-            )
-      )
-      Runner.doc(withDoc, outDir).map: _ =>
-        Logger.info(s"[output] ${LogFormat.path(outDir)}\n")
+            case app: CompileTask.AppTask =>
+              CompileTask.LibTask(
+                app.sources,
+                app.checkLibs,
+                app.sastDir,
+                app.defaultSourceRoot,
+                options,
+              )
+        )
+        Runner.doc(withDoc, outDir).map: _ =>
+          Logger.info(s"[output] ${LogFormat.path(outDir)}\n")
 
   def deps(project: Project, module: ModuleId)(using Logger, PackageProvider): Result[Unit] =
     depsResult(project, module).map: output =>
@@ -221,19 +223,14 @@ object Build:
   private def writeLock(path: Path, pkgs: List[ResolvedPackage])(using provider: PackageProvider): Result[Unit] =
     makeLock(pkgs).flatMap(LockFile.write(path, _))
 
-  private def docOptions(project: Project, module: ModuleId): List[String] =
-    val docSpec = project.doc.getOrElse(DocSpec())
+  private def docOptions(project: Project, module: ModuleId, userOptions: List[String]): List[String] =
     val options = mutable.ArrayBuffer[String](
       "--doc",
       "--out",
       project.buildDir(module).resolve("doc").toString,
-      "--title",
-      docSpec.title.getOrElse(module.value),
     )
+    if !userOptions.contains("--title") then options ++= List("--title", module.value)
     project.pkg(module).foreach(p => options ++= List("--project-version", p.version))
-    docSpec.readme.foreach(r => options ++= List("--readme", project.dir.resolve(r).toString))
-    if docSpec.includePrivate then options += "--include-private"
-    if docSpec.includeSource then options += "--include-source"
     options.toList
 
   private def warnUnusedPinning(resolved: ResolutionResult)(using Logger): Unit =

--- a/stack-lang/tool/BuildSpec.scala
+++ b/stack-lang/tool/BuildSpec.scala
@@ -40,6 +40,7 @@ case class ModuleSpec(
   packageDeps: List[PackageDepSpec],
   links: List[LinkSpec],        // defer-sym -> target-sym
   compileOptions: List[String] = Nil,  // extra flags passed to `jo compile`
+  docOptions: List[String] = Nil,      // extra flags passed to `jo compile --doc`
   pkg: Option[PackageSpec] = None,
 ):
   /** This module's own direct (not transitive) check-visible registry package deps. */
@@ -64,17 +65,9 @@ case class PackageSpec(
   keywords: List[String] = Nil,
 )
 
-case class DocSpec(
-  title: Option[String] = None,
-  readme: Option[String] = None,
-  includePrivate: Boolean = false,
-  includeSource: Boolean = false,
-)
-
 case class BuildSpec(
   jo: VersionSpec,              // compiler compatibility line, e.g. "1.0"
   pinning: Map[String, Version] = Map.empty, // root-only exact resolver overrides
-  doc: Option[DocSpec],
   defaultModule: Option[ModuleId],
   modules: List[ModuleDef],
   commands: Map[String, String] = Map.empty, // [commands] -> `jo <name>` shell aliases
@@ -98,7 +91,8 @@ object BuildSpec:
       throw TomlError("'depth' is no longer supported at the top level; set depth under [module.<id>]")
 
     val pinning = doc.get("pinning").map(v => decodePinning(asTbl(v, "pinning"))).getOrElse(Map.empty)
-    val docSpec = doc.get("doc").map(v => decodeDoc(asTbl(v, "doc")))
+    if doc.contains("doc") then
+      throw TomlError("'[doc]' is no longer supported; set doc-options under [module.<id>]")
     val default = doc.get("default").map(v => ModuleId(validateModuleId(asStr(v, "default"), "default")))
     val modules = decodeModules(doc.get("module"))
     val commands = doc.get("commands").map(v => decodeCommands(asTbl(v, "commands"))).getOrElse(Map.empty)
@@ -110,7 +104,7 @@ object BuildSpec:
       if !modules.exists(_.id == id) then
         throw TomlError(s"default module '${id.value}' is not defined")
 
-    BuildSpec(jo, pinning, docSpec, default, modules, commands)
+    BuildSpec(jo, pinning, default, modules, commands)
 
   private def decodeModules(value: Option[TomlValue]): List[ModuleDef] =
     value match
@@ -148,6 +142,7 @@ object BuildSpec:
     val packageDeps = tbl.get("packages").map(v => decodePackageDeps(v, id)).getOrElse(Nil)
     val links = tbl.get("links").map(v => decodeLinks(v, id)).getOrElse(Nil)
     val compileOptions = tbl.get("compile-options").map(asStrList(_, s"module.${id.value}.compile-options")).getOrElse(Nil)
+    val docOptions = tbl.get("doc-options").map(asStrList(_, s"module.${id.value}.doc-options")).getOrElse(Nil)
     val pkg = tbl.get("package").map(v => decodePackage(asTbl(v, s"module.${id.value}.package"), id))
 
     if kind == ModuleKind.App then
@@ -166,7 +161,7 @@ object BuildSpec:
     if enableFfi && platform.getOrElse(Platform.Pure) == Platform.Pure then
       throw TomlError(s"module.${id.value}.enable-ffi requires platform = \"python\" or platform = \"ruby\"")
 
-    ModuleSpec(kind, src, resources, platform, enableFfi, depth, moduleDeps, packageDeps, links, compileOptions, pkg)
+    ModuleSpec(kind, src, resources, platform, enableFfi, depth, moduleDeps, packageDeps, links, compileOptions, docOptions, pkg)
 
   /** `modules = ["api", { id = "helpers", path = "../lib" }]`
    *  A bare string is shorthand for `{ id = "<string>" }`.
@@ -302,13 +297,6 @@ object BuildSpec:
     validateVersion(version, s"$ctx.version")
 
     PackageSpec(name, version, description, authors, homepage, license, keywords)
-
-  private def decodeDoc(tbl: Map[String, TomlValue]): DocSpec =
-    val title = tbl.get("title").map(asStr(_, "[doc].title"))
-    val readme = tbl.get("readme").map(asStr(_, "[doc].readme"))
-    val includePrivate = tbl.get("include-private").map(asBool(_, "[doc].include-private")).getOrElse(false)
-    val includeSource = tbl.get("include-source").map(asBool(_, "[doc].include-source")).getOrElse(false)
-    DocSpec(title, readme, includePrivate, includeSource)
 
   private def validateModuleId(id: String, ctx: String): String =
     if id.isEmpty || !isAsciiLetter(id.head) || !id.tail.forall(c => isAsciiLetterOrDigit(c) || c == '-') then

--- a/stack-lang/tool/Planner.scala
+++ b/stack-lang/tool/Planner.scala
@@ -317,7 +317,7 @@ object Planner:
       case Some(target) => Result.Ok(target)
       case None         => Result.Err(s"module '${module.value}' has no app platform")
 
-  private def ffiCompileOptions(module: ModuleSpec): List[String] =
+  private[tool] def ffiCompileOptions(module: ModuleSpec): List[String] =
     if module.enableFfi then
       module.platform.flatMap(_.target).toList.flatMap(target => List("--use-runtime-api", target.flag))
     else

--- a/stack-lang/tool/Project.scala
+++ b/stack-lang/tool/Project.scala
@@ -70,8 +70,6 @@ final class Project private (
   def pkg(id: ModuleId): Option[PackageSpec] =
     module(id).flatMap(_.pkg)
 
-  def doc: Option[DocSpec] = spec.doc
-
   def commands: Map[String, String] = spec.commands
 
   def declaredPlatform(id: ModuleId): Platform =

--- a/stack-lang/tool/ToolPrinter.scala
+++ b/stack-lang/tool/ToolPrinter.scala
@@ -10,11 +10,6 @@ object ToolPrinter:
       for (name, version) <- spec.pinning.toSeq.sortBy(_._1) do
         sb.append(s"  $name = ${str(version.toString)}\n")
 
-    spec.doc.foreach: d =>
-      d.title.foreach(t => sb.append(s"doc.title = ${str(t)}\n"))
-      if d.includePrivate then sb.append("doc.include-private = true\n")
-      if d.includeSource then sb.append("doc.include-source = true\n")
-
     for module <- spec.modules do
       sb.append(s"module.${module.id.value}:\n")
       appendSection(sb, module.spec, "  ")
@@ -67,6 +62,7 @@ object ToolPrinter:
     if s.enableFfi then sb.append(s"${pad}enable-ffi = true\n")
     s.depth.foreach(d => sb.append(s"${pad}depth = $d\n"))
     if s.compileOptions.nonEmpty then sb.append(s"${pad}compile-options = ${strList(s.compileOptions)}\n")
+    if s.docOptions.nonEmpty then sb.append(s"${pad}doc-options = ${strList(s.docOptions)}\n")
 
     s.pkg.foreach: p =>
       sb.append(s"${pad}package:\n")

--- a/tests/custom/doc-query/test.sh
+++ b/tests/custom/doc-query/test.sh
@@ -136,6 +136,16 @@ run_query --lib "$SAST_DIR" --query "DocQueryAPI" > "$DIR/lib-query.json"
 run_query --lib "$SAST_DIR" --query "DocQueryAPI.Box.label" > "$DIR/lib-exact-member.json"
 run_query --lib "$SAST_DIR" --query "file:api.jo" > "$DIR/lib-file-query.json"
 
+# A public type and a private companion section may share a qualified name.
+# The private companion must not make a successful public-type query fail.
+run_plain_query --query "jo.String" --fields name,kind > "$DIR/stdlib-companion.json"
+grep -q -- '"name": "jo.String"' "$DIR/stdlib-companion.json"
+grep -q -- '"kind": "class"' "$DIR/stdlib-companion.json"
+if grep -q -- 'jo.String.LineIterator' "$DIR/stdlib-companion.json"; then
+    echo "Private stdlib companion member leaked into query output"
+    exit 1
+fi
+
 diff -u "$DIR/structural.json.check" "$DIR/structural.json"
 diff -u "$DIR/structural.json.check" "$DIR/file.json"
 diff -u "$DIR/structural.json.check" "$DIR/file-absolute.json"

--- a/tests/tool-build/doc/jo.steps
+++ b/tests/tool-build/doc/jo.steps
@@ -4,6 +4,8 @@ jo doc
 
 ! grep -q -x -- '--fatal-warnings' .build/app/doc.done
 grep -q -x -- '--readme' .build/app/doc.done
+test "$(grep -c -x -- '--source-root' .build/app/doc.done)" -eq 1
+awk 'previous == "--source-root" { found = ($0 == "tests/tool-build/doc") } { previous = $0 } END { exit !found }' .build/app/doc.done
 
 test -f .build/app/doc/index.html
 : ''

--- a/tests/tool-build/doc/jo.steps
+++ b/tests/tool-build/doc/jo.steps
@@ -2,6 +2,9 @@ rm -rf .build
 
 jo doc
 
+! grep -q -x -- '--fatal-warnings' .build/app/doc.done
+grep -q -x -- '--readme' .build/app/doc.done
+
 test -f .build/app/doc/index.html
 : ''
 

--- a/tests/tool-build/doc/jo.toml
+++ b/tests/tool-build/doc/jo.toml
@@ -4,8 +4,12 @@ jo = "1.0"
 kind = "app"
 platform = "python"
 src = ["src/"]
-compile-options = ["--fatal-warnings"]
-doc-options = ["--title", "Doc Demo", "--readme", "tests/tool-build/doc/README.md"]
+compile-options = ["--fatal-warnings", "--source-root", "wrong-root"]
+doc-options = [
+  "--title", "Doc Demo",
+  "--readme", "tests/tool-build/doc/README.md",
+  "--source-root", "tests/tool-build/doc",
+]
 
 [module.app.package]
 name = "doc-demo"

--- a/tests/tool-build/doc/jo.toml
+++ b/tests/tool-build/doc/jo.toml
@@ -1,13 +1,11 @@
 jo = "1.0"
 
-[doc]
-title = "Doc Demo"
-readme = "README.md"
-
 [module.app]
 kind = "app"
 platform = "python"
 src = ["src/"]
+compile-options = ["--fatal-warnings"]
+doc-options = ["--title", "Doc Demo", "--readme", "tests/tool-build/doc/README.md"]
 
 [module.app.package]
 name = "doc-demo"

--- a/tests/tool-toml/build-spec/full.toml
+++ b/tests/tool-toml/build-spec/full.toml
@@ -4,17 +4,14 @@ default = "app"
 [pinning]
 mustache = "1.2.3"
 
-[doc]
-title = "My App API"
-include-private = true
-include-source = true
-
 [module.app]
 kind = "app"
 src = ["src/", "vendor/"]
 resources = ["assets/", "public/logo.svg:logo.svg"]
 platform = "python"
 depth = 2
+compile-options = ["--fatal-warnings"]
+doc-options = ["--title", "My App API", "--include-private"]
 
 modules = [
   { id = "utils", path = "../utils" },

--- a/tests/tool-toml/build-spec/full.txt
+++ b/tests/tool-toml/build-spec/full.txt
@@ -2,15 +2,14 @@ jo = "1.0"
 default = "app"
 pinning:
   mustache = "1.2.3"
-doc.title = "My App API"
-doc.include-private = true
-doc.include-source = true
 module.app:
   kind = "app"
   src = ["src/", "vendor/"]
   resources = ["assets", "public/logo.svg:logo.svg"]
   platform = "python"
   depth = 2
+  compile-options = ["--fatal-warnings"]
+  doc-options = ["--title", "My App API", "--include-private"]
   modules:
     - "utils" path "../utils"
     - "agent-runtime" path "../runtime" [link]

--- a/tests/tool-toml/build-spec/invalid-top-level-doc.toml
+++ b/tests/tool-toml/build-spec/invalid-top-level-doc.toml
@@ -1,0 +1,9 @@
+jo = "1.0"
+
+[doc]
+title = "Old documentation settings"
+
+[module.app]
+kind = "app"
+platform = "python"
+src = ["src/"]

--- a/tests/tool-toml/build-spec/invalid-top-level-doc.txt
+++ b/tests/tool-toml/build-spec/invalid-top-level-doc.txt
@@ -1,0 +1,1 @@
+error: '[doc]' is no longer supported; set doc-options under [module.<id>]


### PR DESCRIPTION
Fix doc tool options

## Summary

Use `compile-options` for build, and `doc-options` for doc generation.

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

Doc build spec needs update if they are used.

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [ ] ~Build spec compatibility: old projects continue to build~
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

