### PR TITLE
Release Jo 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.1] - 2026-08-30
+
+### Added
+
+- Auto parameters of type `jo.compile.SourceLocation` receive a compiler-
+  synthesized source path and line number when no local auto value is available.
+  This lets helpers report the outermost call site without explicit plumbing.
+  ([#103])
+
+### Changed
+
+- `jo doc` now takes compiler documentation flags verbatim from each module's
+  `doc-options`. The top-level `[doc]` table is no longer supported, and normal
+  `compile-options` no longer affect documentation generation. ([#103])
+
+### Fixed
+
+- `jo compile --query` no longer reports a false missing-entry error when a
+  selector such as `jo.String` resolves to equivalent symbols loaded from
+  multiple compilation units. ([#103])
+
+### Security
+
+- No security-relevant changes.
+
+### Compatibility
+
+- Build specs with a top-level `[doc]` table must move those settings to the
+  documented module's `doc-options` array. ([#103])
+- No library recompilation is required.
+
+[#103]: https://github.com/typescope/jo/pull/103
+
 ## [0.13.0] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.13.0-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.13.0)
+  [![Release](https://img.shields.io/badge/release-v0.13.1-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.13.1)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -12,3 +12,4 @@
 {"version":"0.12.4","url":"https://github.com/typescope/jo/releases/download/v0.12.4/jo-0.12.4.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.4/jo-0.12.4.tar.gz.sha256","date":"2026-08-05"}
 {"version":"0.12.5","url":"https://github.com/typescope/jo/releases/download/v0.12.5/jo-0.12.5.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.5/jo-0.12.5.tar.gz.sha256","date":"2026-08-22"}
 {"version":"0.13.0","url":"https://github.com/typescope/jo/releases/download/v0.13.0/jo-0.13.0.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.13.0/jo-0.13.0.tar.gz.sha256","date":"2026-08-25"}
+{"version":"0.13.1","url":"https://github.com/typescope/jo/releases/download/v0.13.1/jo-0.13.1.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.13.1/jo-0.13.1.tar.gz.sha256","date":"2026-08-30"}

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 13, 0)
+  val current: Version = Version(0, 13, 1)


### PR DESCRIPTION
## Summary

- bump Jo to 0.13.1
- document the source-location and doc-tool changes from #103
- update the release badge and public version index

## Verification

- `bin/jo.dev --version` prints `0.13.1`
- `git diff --check` passes