### PR TITLE
Fix parser crash on reserved pattern binders

### DIFF
--- a/stack-lang/parsing/Parser.scala
+++ b/stack-lang/parsing/Parser.scala
@@ -2396,6 +2396,11 @@ class Parser(code: String)(using reporter: Reporter, source: Source):
       else
         pat = simplePattern(prevPattern = pat)
 
+    if patterns.isEmpty then
+      val item = peekItem()
+      error("Expect a pattern, found token " + item.token, item.span.toPos)
+      throw new SyntaxError
+
     patterns.toList match
       case (op: Ident) :: rhs :: Nil if Naming.isOperator(op.name) =>
         ApplyPattern(op, rhs :: Nil)(op.span | rhs.span)

--- a/tests/parsing/reserved-interface-val-binder.jo
+++ b/tests/parsing/reserved-interface-val-binder.jo
@@ -1,0 +1,5 @@
+namespace reservedInterfaceValBinder
+
+def f(): String =
+  val interface = "x"
+  interface

--- a/tests/parsing/reserved-namespace-val-binder.jo
+++ b/tests/parsing/reserved-namespace-val-binder.jo
@@ -1,0 +1,5 @@
+namespace reservedNamespaceValBinder
+
+def f(): String =
+  val namespace = "x"
+  namespace

--- a/tests/parsing/reserved-section-for-binder.jo
+++ b/tests/parsing/reserved-section-for-binder.jo
@@ -1,0 +1,6 @@
+namespace reservedSectionForBinder
+
+def f(xs: List[String]): Int =
+  var n = 0
+  for section in xs do n = n + section.size
+  n

--- a/tests/parsing/reserved-section-val-binder.jo
+++ b/tests/parsing/reserved-section-val-binder.jo
@@ -1,0 +1,5 @@
+namespace reservedSectionValBinder
+
+def f(): String =
+  val section = "x"
+  section

--- a/tests/parsing/reserved-union-val-binder.jo
+++ b/tests/parsing/reserved-union-val-binder.jo
@@ -1,0 +1,5 @@
+namespace reservedUnionValBinder
+
+def f(): String =
+  val union = "x"
+  union

--- a/tests/parsing/reserved-view-val-binder.jo
+++ b/tests/parsing/reserved-view-val-binder.jo
@@ -1,0 +1,5 @@
+namespace reservedViewValBinder
+
+def f(): String =
+  val view = "x"
+  view


### PR DESCRIPTION
Fix parser crashes on reserved words in value binder positions.

## Summary

- reject an empty expression pattern with a source-located parser diagnostic
- cover `section` in both `val` and `for` binder positions
- cover the other reported block keywords (`union`, `view`, `interface`, and `namespace`)

## Checklist

- [x] Added parsing regression tests under `tests/parsing/`
- [x] ~Docs updated if the change affects user-visible behavior~ — diagnostics only
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

## Security impact

No.

## Compatibility impact

Reserved words used as pattern binders now produce a parser diagnostic instead of crashing. Valid source syntax and serialized formats are unchanged.

- [x] Source compatibility: existing valid code continues to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward compatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code works with the new stdlib
- [x] Runtime Library compatibility
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code works with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old `.joy` files can be consumed by the new build tool

## Verification

- `bin/fuzz regress --parse tests/parsing` — all 20 files pass without crashes
- direct parser replay of all six new cases reports `Expect a pattern, found token ...`
- `git diff --check`
