### PR TITLE
Check cast in FFI boundary for primitive types

### DIFF
--- a/docs/guides/javascript-interoperability.md
+++ b/docs/guides/javascript-interoperability.md
@@ -93,11 +93,13 @@ val v: String = process.env["MY_VAR"].asString   // item read
 `js.Dynamic` provides shorthand methods for the four primitive types:
 
 ```jo
-val i: Int    = v.asInt     // equivalent to v.cast[Int]
-val f: Float  = v.asFloat   // equivalent to v.cast[Float]
-val s: String = v.asString  // equivalent to v.cast[String]
-val b: Bool   = v.asBool    // equivalent to v.cast[Bool]
+val i: Int    = v.asInt
+val f: Float  = v.asFloat
+val s: String = v.asString
+val b: Bool   = v.asBool
 ```
+
+Each shortcut validates the JavaScript value and aborts with a descriptive error on mismatch. Because JavaScript represents both Jo `Int` and `Float` values as numbers, `asFloat` accepts any number; `asInt` additionally requires `Number.isInteger(value)`. The generic `cast[T]` remains unchecked.
 
 Use `asString` when you know the value is already a JavaScript `string`. Use `toString` (see below) when you want a human-readable representation of an arbitrary value.
 

--- a/docs/guides/python-interoperability.md
+++ b/docs/guides/python-interoperability.md
@@ -98,11 +98,13 @@ val b: Bool   = someValue.cast[Bool]
 `py.Dynamic` provides shorthand methods for the four primitive types:
 
 ```jo
-val i: Int    = v.asInt     // equivalent to v.cast[Int]
-val f: Float  = v.asFloat   // equivalent to v.cast[Float]
-val s: String = v.asString  // equivalent to v.cast[String]
-val b: Bool   = v.asBool    // equivalent to v.cast[Bool]
+val i: Int    = v.asInt
+val f: Float  = v.asFloat
+val s: String = v.asString
+val b: Bool   = v.asBool
 ```
+
+Each shortcut checks that the value has exactly the corresponding Python type and aborts with a descriptive error if it does not. In particular, `asInt` rejects Python `bool` values even though Python treats `bool` as a subclass of `int`. The generic `cast[T]` remains an unchecked reinterpretation for typed wrappers and other advanced uses.
 
 Use `asString` when you know the value is already a Python `str`. Use `toString` (see below) when you want a human-readable representation of an arbitrary value.
 

--- a/docs/guides/ruby-interoperability.md
+++ b/docs/guides/ruby-interoperability.md
@@ -154,11 +154,13 @@ val s: String = someValue.cast[String]
 `rb.Dynamic` provides shorthand methods for the four primitive types:
 
 ```jo
-val i: Int    = v.asInt     // equivalent to v.cast[Int]
-val f: Float  = v.asFloat   // equivalent to v.cast[Float]
-val s: String = v.asString  // equivalent to v.cast[String]
-val b: Bool   = v.asBool    // equivalent to v.cast[Bool]
+val i: Int    = v.asInt
+val f: Float  = v.asFloat
+val s: String = v.asString
+val b: Bool   = v.asBool
 ```
+
+Each shortcut checks that the value has the corresponding Ruby primitive class and aborts with a descriptive error if it does not. `asBool` accepts both `TrueClass` and `FalseClass`. The generic `cast[T]` remains unchecked.
 
 Use `asString` when you know the value is already a Ruby `String`. Use `toString` (see below) when you want a human-readable representation of an arbitrary value.
 

--- a/runtime/javascript/js.jo
+++ b/runtime/javascript/js.jo
@@ -152,22 +152,38 @@ interface Dynamic
   //]
   def toString: String
 
-  //[ Reinterpret this JavaScript value as a Jo String.
+  //[ Return this JavaScript value as a Jo String.
     !
     ! The value must already be a JavaScript `string`; no conversion is performed.
     ! Use `toString` instead when you need a human-readable representation of
     ! an arbitrary JavaScript value.
   //]
-  def asString: String = cast[String]
+  def asString: String =
+    val actual = js.typeof(this)
+    if actual != "string" then
+      abort("js.Dynamic.asString: expected JavaScript string, got " + actual)
+    cast[String]
 
-  //[ Reinterpret this JavaScript value as a Jo Int.   //]
-  def asInt: Int = cast[Int]
+  //[ Return this JavaScript value as a Jo Int, aborting unless it is an integer-valued number.   //]
+  def asInt: Int =
+    val actual = js.typeof(this)
+    if actual != "number" || !js.global.Number.isInteger(this).cast[Bool] then
+      abort("js.Dynamic.asInt: expected JavaScript integer number, got " + actual)
+    cast[Int]
 
-  //[ Reinterpret this JavaScript value as a Jo Float.   //]
-  def asFloat: Float = cast[Float]
+  //[ Return this JavaScript value as a Jo Float, aborting unless it is a number.   //]
+  def asFloat: Float =
+    val actual = js.typeof(this)
+    if actual != "number" then
+      abort("js.Dynamic.asFloat: expected JavaScript number, got " + actual)
+    cast[Float]
 
-  //[ Reinterpret this JavaScript value as a Jo Bool.   //]
-  def asBool: Bool = cast[Bool]
+  //[ Return this JavaScript value as a Jo Bool, aborting unless it is a boolean.   //]
+  def asBool: Bool =
+    val actual = js.typeof(this)
+    if actual != "boolean" then
+      abort("js.Dynamic.asBool: expected JavaScript boolean, got " + actual)
+    cast[Bool]
 
   //[ Test whether this JavaScript value is `undefined`.   //]
   def isUndefined: Bool = js.isUndefined(this)

--- a/runtime/python/Runtime.jo
+++ b/runtime/python/Runtime.jo
@@ -124,11 +124,11 @@ end
 private def reModule: py.Dynamic = py.module("re")
 
 private section RegexEngine
-  def ignoreCaseFlag: Int = reModule.IGNORECASE.asInt
+  def ignoreCaseFlag: Int = reModule.IGNORECASE.value.asInt
 
-  def multilineFlag: Int = reModule.MULTILINE.asInt
+  def multilineFlag: Int = reModule.MULTILINE.value.asInt
 
-  def dotAllFlag: Int = reModule.DOTALL.asInt
+  def dotAllFlag: Int = reModule.DOTALL.value.asInt
 
   def compileFlags(flags: String): Int =
     var bits = 0

--- a/runtime/python/py.jo
+++ b/runtime/python/py.jo
@@ -188,8 +188,8 @@ interface Dynamic
     ! This is the safe conversion path: use it when you want a human-readable
     ! string representation of any `py.Dynamic`.
     !
-    ! Contrast with `asString`, which is an unsafe cast asserting the value is
-    ! already a Python `str` with no conversion.
+    ! Contrast with `asString`, which checks that the value is already a Python
+    ! `str` and returns it without conversion.
     !
     ! Because Jo uses `toString` as the standard string-conversion adapter,
     ! `py.Dynamic` will also work transparently in string concatenation and
@@ -197,22 +197,38 @@ interface Dynamic
   //]
   def toString: String = py.str(this)
 
-  //[ Reinterpret this Python value as a Jo String.
+  //[ Return this Python value as a Jo String.
     !
-    ! The value must already be a Python `str`; no conversion is performed.
+    ! Aborts unless the value is exactly a Python `str`; no conversion is performed.
     ! Use `toString` instead when you need a human-readable representation of
     ! an arbitrary Python value.
   //]
-  def asString: String = cast[String]
+  def asString: String =
+    val actual = builtins.callDynamic("type", this)
+    if !py.isIdentical(actual, builtins.str) then
+      abort("py.Dynamic.asString: expected Python str, got " + actual.__name__.cast[String])
+    cast[String]
 
-  //[ Reinterpret this Python value as a Jo Int.   //]
-  def asInt: Int = cast[Int]
+  //[ Return this Python value as a Jo Int, aborting unless it is exactly a Python `int`.   //]
+  def asInt: Int =
+    val actual = builtins.callDynamic("type", this)
+    if !py.isIdentical(actual, builtins.int) then
+      abort("py.Dynamic.asInt: expected Python int, got " + actual.__name__.cast[String])
+    cast[Int]
 
-  //[ Reinterpret this Python value as a Jo Float.   //]
-  def asFloat: Float = cast[Float]
+  //[ Return this Python value as a Jo Float, aborting unless it is exactly a Python `float`.   //]
+  def asFloat: Float =
+    val actual = builtins.callDynamic("type", this)
+    if !py.isIdentical(actual, builtins.float) then
+      abort("py.Dynamic.asFloat: expected Python float, got " + actual.__name__.cast[String])
+    cast[Float]
 
-  //[ Reinterpret this Python value as a Jo Bool.   //]
-  def asBool: Bool = cast[Bool]
+  //[ Return this Python value as a Jo Bool, aborting unless it is exactly a Python `bool`.   //]
+  def asBool: Bool =
+    val actual = builtins.callDynamic("type", this)
+    if !py.isIdentical(actual, builtins.bool) then
+      abort("py.Dynamic.asBool: expected Python bool, got " + actual.__name__.cast[String])
+    cast[Bool]
 
   //[ Test whether this Python value is Python None.   //]
   def isNone: Bool = py.isNone(this)

--- a/runtime/ruby/rb.jo
+++ b/runtime/ruby/rb.jo
@@ -154,22 +154,38 @@ interface Dynamic
   //]
   def toString: String = rb.dynamic(this).to_s.asString
 
-  //[ Reinterpret this Ruby value as a Jo String.
+  //[ Return this Ruby value as a Jo String.
     !
     ! The value must already be a Ruby `String`; no conversion is performed.
     ! Use `toString` instead when you need a human-readable representation of
     ! an arbitrary Ruby value.
   //]
-  def asString: String = cast[String]
+  def asString: String =
+    val actual = rb.dynamic(this).callDynamic("class")
+    if !rb.isIdentical(actual, rb.const("String")) then
+      abort("rb.Dynamic.asString: expected Ruby String, got " + actual.callDynamic("name").cast[String])
+    cast[String]
 
-  //[ Reinterpret this Ruby value as a Jo Int.   //]
-  def asInt: Int = cast[Int]
+  //[ Return this Ruby value as a Jo Int, aborting unless it is exactly a Ruby `Integer`.   //]
+  def asInt: Int =
+    val actual = rb.dynamic(this).callDynamic("class")
+    if !rb.isIdentical(actual, rb.const("Integer")) then
+      abort("rb.Dynamic.asInt: expected Ruby Integer, got " + actual.callDynamic("name").cast[String])
+    cast[Int]
 
-  //[ Reinterpret this Ruby value as a Jo Float.   //]
-  def asFloat: Float = cast[Float]
+  //[ Return this Ruby value as a Jo Float, aborting unless it is exactly a Ruby `Float`.   //]
+  def asFloat: Float =
+    val actual = rb.dynamic(this).callDynamic("class")
+    if !rb.isIdentical(actual, rb.const("Float")) then
+      abort("rb.Dynamic.asFloat: expected Ruby Float, got " + actual.callDynamic("name").cast[String])
+    cast[Float]
 
-  //[ Reinterpret this Ruby value as a Jo Bool.   //]
-  def asBool: Bool = cast[Bool]
+  //[ Return this Ruby value as a Jo Bool, aborting unless it is Ruby `true` or `false`.   //]
+  def asBool: Bool =
+    val actual = rb.dynamic(this).callDynamic("class")
+    if !rb.isIdentical(actual, rb.const("TrueClass")) && !rb.isIdentical(actual, rb.const("FalseClass")) then
+      abort("rb.Dynamic.asBool: expected Ruby boolean, got " + actual.callDynamic("name").cast[String])
+    cast[Bool]
 
   //[ Test whether this Ruby value is Ruby nil.   //]
   def isNil: Bool = rb.isNil(this)

--- a/tests/custom/js-ffi/app.jo
+++ b/tests/custom/js-ffi/app.jo
@@ -20,6 +20,7 @@ def main =
   testDynamic()
   testCall()
   testToString()
+  testCheckedAccessors()
 
 //[ 1. js.global + selectDynamic / callDynamic //]
 def testGlobal =
@@ -236,3 +237,27 @@ def testToString =
   // toString on array (gives comma-joined)
   val arr: js.Array = js.array(1, 2, 3)
   println("toString [1,2,3] = " + js.dynamic(arr).toString)
+
+//[ 16. Primitive accessors reject values of the wrong JavaScript type //]
+def testCheckedAccessors =
+  println "--- checked accessors ---"
+
+  match js.try(js.dynamic("not an int").asInt)
+    case Ok(_)  => println "asInt unexpectedly accepted string"
+    case Err(e) => println e.asString
+
+  match js.try(js.dynamic(1.5).asInt)
+    case Ok(_)  => println "asInt unexpectedly accepted fractional number"
+    case Err(e) => println e.asString
+
+  match js.try(js.dynamic("not a float").asFloat)
+    case Ok(_)  => println "asFloat unexpectedly accepted string"
+    case Err(e) => println e.asString
+
+  match js.try(js.dynamic(1).asBool)
+    case Ok(_)  => println "asBool unexpectedly accepted number"
+    case Err(e) => println e.asString
+
+  match js.try(js.dynamic(1).asString)
+    case Ok(_)  => println "asString unexpectedly accepted number"
+    case Err(e) => println e.asString

--- a/tests/custom/js-ffi/expect.check
+++ b/tests/custom/js-ffi/expect.check
@@ -74,3 +74,9 @@ call isArray(42) = false
 --- toString ---
 toString 42 = 42
 toString [1,2,3] = 1,2,3
+--- checked accessors ---
+js.Dynamic.asInt: expected JavaScript integer number, got string
+js.Dynamic.asInt: expected JavaScript integer number, got number
+js.Dynamic.asFloat: expected JavaScript number, got string
+js.Dynamic.asBool: expected JavaScript boolean, got number
+js.Dynamic.asString: expected JavaScript string, got number

--- a/tests/custom/python-dynamic/app.jo
+++ b/tests/custom/python-dynamic/app.jo
@@ -9,6 +9,7 @@ def main =
   testChainedAccess()
   testCallWithKwarg()
   testCallWithSplice()
+  testCheckedAccessors()
 
 //[ 1. importModule + selectDynamic (attribute read) //]
 def testImportAndSelect =
@@ -26,10 +27,10 @@ def testCallDynamic =
   println "--- callDynamic ---"
   val math: py.Dynamic = py.module("math")
 
-  val floor: Float = math.floor(2.7).asFloat
+  val floor: Int = math.floor(2.7).asInt
   println("floor(2.7) = " + floor.toString)
 
-  val ceil: Float = math.ceil(2.1).asFloat
+  val ceil: Int = math.ceil(2.1).asInt
   println("ceil(2.1) = " + ceil.toString)
 
   val sqrt: Float = math.sqrt(9.0).asFloat
@@ -136,3 +137,28 @@ def testCallWithSplice =
   // max(*[1, 7, 3]) = 7 via native splice
   val maxResult: Int = builtins.max(..[1, 7, 3]).asInt
   println("max(*[1,7,3]) = " + maxResult.toString)
+
+//[ 10. Primitive accessors reject values of the wrong Python type //]
+def testCheckedAccessors =
+  println "--- checked accessors ---"
+  val builtins: py.Dynamic = py.module("builtins")
+
+  match py.try(builtins.str("not an int").asInt)
+    case Ok(_)  => println "asInt unexpectedly accepted str"
+    case Err(e) => println e.message
+
+  match py.try(builtins.int(1).asFloat)
+    case Ok(_)  => println "asFloat unexpectedly accepted int"
+    case Err(e) => println e.message
+
+  match py.try(builtins.bool(true).asInt)
+    case Ok(_)  => println "asInt unexpectedly accepted bool"
+    case Err(e) => println e.message
+
+  match py.try(builtins.int(1).asBool)
+    case Ok(_)  => println "asBool unexpectedly accepted int"
+    case Err(e) => println e.message
+
+  match py.try(builtins.int(1).asString)
+    case Ok(_)  => println "asString unexpectedly accepted int"
+    case Err(e) => println e.message

--- a/tests/custom/python-dynamic/expect.check
+++ b/tests/custom/python-dynamic/expect.check
@@ -26,3 +26,9 @@ sep = /
 capwords = Jo-Ffi
 --- callDynamic + splice ---
 max(*[1,7,3]) = 7
+--- checked accessors ---
+py.Dynamic.asInt: expected Python int, got str
+py.Dynamic.asFloat: expected Python float, got int
+py.Dynamic.asInt: expected Python int, got bool
+py.Dynamic.asBool: expected Python bool, got int
+py.Dynamic.asString: expected Python str, got int

--- a/tests/custom/python-ffi/app.jo
+++ b/tests/custom/python-ffi/app.jo
@@ -9,7 +9,7 @@ def main =
   println("pi = " + pi)
 
   // Test callDynamic with single arg
-  val floorResult: Float = math.floor(2.7).asFloat
+  val floorResult: Int = math.floor(2.7).asInt
   println("floor(2.7) = " + floorResult)
 
   // Test splice: max(*[1, 7, 3]) -> 7 via native splice

--- a/tests/custom/ruby-ffi/app.jo
+++ b/tests/custom/ruby-ffi/app.jo
@@ -97,3 +97,24 @@ def main: Unit =
   println("json parse answer = " + answer)
   val serialized: String = json.callDynamic("generate", parsed).asString
   println("json roundtrip contains answer = " + (serialized.indexOf("42") >= 0))
+
+  testCheckedAccessors()
+
+def testCheckedAccessors: Unit =
+  println "--- checked accessors ---"
+
+  match rb.try(rb.dynamic("not an int").asInt)
+    case Ok(_)  => println "asInt unexpectedly accepted String"
+    case Err(e) => println e.message
+
+  match rb.try(rb.dynamic(1).asFloat)
+    case Ok(_)  => println "asFloat unexpectedly accepted Integer"
+    case Err(e) => println e.message
+
+  match rb.try(rb.dynamic(1).asBool)
+    case Ok(_)  => println "asBool unexpectedly accepted Integer"
+    case Err(e) => println e.message
+
+  match rb.try(rb.dynamic(1).asString)
+    case Ok(_)  => println "asString unexpectedly accepted Integer"
+    case Err(e) => println e.message

--- a/tests/custom/ruby-ffi/expect.check
+++ b/tests/custom/ruby-ffi/expect.check
@@ -26,3 +26,8 @@ name after update = Bob
 toString(42) = 42
 json parse answer = 42
 json roundtrip contains answer = true
+--- checked accessors ---
+rb.Dynamic.asInt: expected Ruby Integer, got String
+rb.Dynamic.asFloat: expected Ruby Float, got Integer
+rb.Dynamic.asBool: expected Ruby boolean, got Integer
+rb.Dynamic.asString: expected Ruby String, got Integer


### PR DESCRIPTION
Check cast in FFI boundary for primitive types

## Summary

This will make it easier to catch accidental errors in programming.

## What has changed

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] Docs updated if the change affects user-visible behavior
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

---