### PR TITLE
Harden invariants about applications

### DIFF
--- a/stack-lang/sast/Trees.scala
+++ b/stack-lang/sast/Trees.scala
@@ -727,7 +727,16 @@ object Trees:
     def select(name: String)(using Definitions): Word =
       Select(word, name)(word.span)
 
-    /** No adaption is performed except for numeric adaptation */
+    /** Apply the word to the given arguments
+      *
+      * No adaptation is performed: the caller is responsible for supplying
+      * arguments that already conform to the parameter types.
+      *
+      * Both the arguments and the parameter types must be fully instantiated.
+      * Inference variables may not reach tree construction: an erroneous or
+      * still uninstantiated argument must be handled by the caller, which
+      * should propagate the error instead of building an application from it.
+      */
     def appliedTo(args: Word*)(using defn: Definitions): Word =
       val procType = word.tpe.asProcType
 
@@ -736,6 +745,8 @@ object Trees:
       assert(procType.autos.isEmpty, "autos not supplied")
 
       for (arg, paramType) <- args.zip(procType.paramTypes) do
+        assert(arg.tpe.isFullyInstantiated, "not fully instantiated: " + arg.tpe.show)
+        assert(paramType.isFullyInstantiated, "not fully instantiated: " + paramType.show)
         assert(
           Subtyping.conforms(arg.tpe, paramType),
           s"argument type ${arg.tpe.show} does not conform to parameter type ${paramType.show} in ${word.show}",

--- a/stack-lang/typing/Applications.scala
+++ b/stack-lang/typing/Applications.scala
@@ -291,6 +291,59 @@ trait Applications extends DynamicTyper:
         errorWord(arg.span)
 
 
+  /** Build an application from arguments that are already typed
+    *
+    * This is the error-tolerant counterpart of `Trees.appliedTo`, which
+    * requires the arguments to already conform to the parameter types. Here
+    * each argument is adapted to its parameter type, which also takes care of
+    * inference when either side is not yet fully instantiated. The result may
+    * therefore still contain unconstrained type variables --- they are
+    * resolved, or reported, by the enclosing isolate.
+    *
+    * When the application cannot be built, a dummy word of the result type is
+    * returned, so that typing of the enclosing expression can continue.
+    */
+  def applyTypedArgs(fun: Word, args: List[Word], applySpan: Span)
+      (using defn: Definitions, sc: Scope, rp: Reporter, so: Source, tvars: TypeVars)
+  : Word =
+
+    if fun.tpe.isError then
+      errorWord(applySpan)
+
+    else if !fun.tpe.isProcType then
+      Reporter.error("Not a function: " + fun.tpe.show, fun.pos)
+      errorWord(applySpan)
+
+    else
+      val procType = fun.tpe.asProcType
+      val paramTypes = procType.paramTypes
+
+      assert(procType.tparams.isEmpty, "type params not supplied")
+      assert(procType.autos.isEmpty, "autos not supplied")
+
+      def dummy = dummyWord(procType.resultType, applySpan)
+
+      if paramTypes.size != args.size then
+        Reporter.error(
+          s"The function expects ${paramTypes.size} argument(s), found = ${args.size}",
+          applySpan.toPos)
+        dummy
+
+      else if args.exists(_.tpe.isError) then
+        dummy
+
+      else
+        val args2 =
+          for (arg, paramType) <- args.zip(paramTypes) yield
+            Checker.adapt(arg, TargetType.Known(paramType))
+
+        if args2.exists(_.tpe.isError) then
+          dummy
+
+        else
+          val span = args2.foldLeft(fun.span)(_ | _.span)
+          Apply(fun, args2, autos = Nil)(span)
+
   /** Assumes that the argument count requirement is satisfied */
   def transformVarargs
       (args: List[Ast.Word], paramTypes: List[Type], span: Span)
@@ -313,7 +366,7 @@ trait Applications extends DynamicTyper:
       val argTyped = transformArg(arg, paramTypeFlex)
 
       if !argTyped.tpe.isError then
-        lastFlexArg = lastFlexArg.select("++").appliedTo(argTyped)
+        lastFlexArg = applyTypedArgs(lastFlexArg.select("++"), argTyped :: Nil, argTyped.span)
 
     for arg <- argsFlex do
       arg match
@@ -341,7 +394,7 @@ trait Applications extends DynamicTyper:
         case _ =>
           val argTyped = transformArg(arg, elementType)
           if !argTyped.tpe.isError then
-            lastFlexArg = lastFlexArg.select("+").appliedTo(argTyped)
+            lastFlexArg = applyTypedArgs(lastFlexArg.select("+"), argTyped :: Nil, argTyped.span)
       end match
 
     argsFixTyped :+ lastFlexArg
@@ -490,7 +543,7 @@ trait Applications extends DynamicTyper:
       // Splice target types as List[T] (Mixed[T] = T at runtime)
       val argTyped = transformArg(arg, paramTypeFlex)
       if !argTyped.tpe.isError then
-        lastFlexArg = lastFlexArg.select("++").appliedTo(argTyped)
+        lastFlexArg = applyTypedArgs(lastFlexArg.select("++"), argTyped :: Nil, argTyped.span)
 
     for callArg <- flexCallArgs do
       callArg match
@@ -512,13 +565,13 @@ trait Applications extends DynamicTyper:
         case word: Ast.Word =>
           val argTyped = transformArg(word, elementType)
           if !argTyped.tpe.isError then
-            lastFlexArg = lastFlexArg.select("+").appliedTo(argTyped)
+            lastFlexArg = applyTypedArgs(lastFlexArg.select("+"), argTyped :: Nil, argTyped.span)
 
         case namedArg: Ast.NamedArg =>
           val argTyped = transformArg(namedArg.arg, elementType)
           if !argTyped.tpe.isError then
             val wrapped = wrapNamedArg(namedArg.name, argTyped)
-            lastFlexArg = lastFlexArg.select("+").appliedTo(wrapped)
+            lastFlexArg = applyTypedArgs(lastFlexArg.select("+"), wrapped :: Nil, wrapped.span)
 
     Some(fixedTyped :+ lastFlexArg)
 
@@ -580,7 +633,7 @@ trait Applications extends DynamicTyper:
           val argTyped = transformArg(namedArg.arg, elementType)
           if !argTyped.tpe.isError then
             val wrapped = wrapNamedArg(namedArg.name, argTyped)
-            lastFlexArg = lastFlexArg.select("+").appliedTo(wrapped)
+            lastFlexArg = applyTypedArgs(lastFlexArg.select("+"), wrapped :: Nil, wrapped.span)
         case _ =>
 
     Some(fixedTyped :+ lastFlexArg)

--- a/tests/warn/flow-typing-uninferred-and.jo
+++ b/tests/warn/flow-typing-uninferred-and.jo
@@ -1,0 +1,4 @@
+// `&&` operand whose type is left uninferred
+def main(): Unit =
+  if true && ("k" ~ undefinedVar) then
+    println "yes"

--- a/tests/warn/flow-typing-uninferred-and.jo.check
+++ b/tests/warn/flow-typing-uninferred-and.jo.check
@@ -1,0 +1,16 @@
+---------- Error at tests/warn/flow-typing-uninferred-and.jo:3:21 ---------------
+|   if true && ("k" ~ undefinedVar) then
+|                     ^^^^^^^^^^^^
+|                     Undefined term name undefinedVar
+
+---------- Error at tests/warn/flow-typing-uninferred-and.jo:3:15 ---------------
+|   if true && ("k" ~ undefinedVar) then
+|               ^^^^^^^^^^^^^^^^^^
+|               Expect type Bool, found = String ~ ?T
+
+---------- Error at tests/warn/flow-typing-uninferred-and.jo:3:20 ---------------
+|   if true && ("k" ~ undefinedVar) then
+|                    ^
+|                    Cannot infer a type for type variable ?T
+
+3 error(s), 0 warning(s)

--- a/tests/warn/flow-typing-uninferred-or.jo
+++ b/tests/warn/flow-typing-uninferred-or.jo
@@ -1,0 +1,4 @@
+// `||` operand whose type is left uninferred
+def main(): Unit =
+  if false || ("k" ~ undefinedVar) then
+    println "yes"

--- a/tests/warn/flow-typing-uninferred-or.jo.check
+++ b/tests/warn/flow-typing-uninferred-or.jo.check
@@ -1,0 +1,16 @@
+---------- Error at tests/warn/flow-typing-uninferred-or.jo:3:22 ---------------
+|   if false || ("k" ~ undefinedVar) then
+|                      ^^^^^^^^^^^^
+|                      Undefined term name undefinedVar
+
+---------- Error at tests/warn/flow-typing-uninferred-or.jo:3:16 ---------------
+|   if false || ("k" ~ undefinedVar) then
+|                ^^^^^^^^^^^^^^^^^^
+|                Expect type Bool, found = String ~ ?T
+
+---------- Error at tests/warn/flow-typing-uninferred-or.jo:3:21 ---------------
+|   if false || ("k" ~ undefinedVar) then
+|                     ^
+|                     Cannot infer a type for type variable ?T
+
+3 error(s), 0 warning(s)

--- a/tests/warn/string-interp-uninferred-class.jo
+++ b/tests/warn/string-interp-uninferred-class.jo
@@ -1,0 +1,9 @@
+// String interpolation part of a class type left uninferred
+class Box[T](value: T)
+  def toString: String = "box"
+end
+
+def make[T](x: T): Box[T] = new Box[T](x)
+
+def main(): Unit =
+  println "a\{make(undefinedVar)}b"

--- a/tests/warn/string-interp-uninferred-class.jo.check
+++ b/tests/warn/string-interp-uninferred-class.jo.check
@@ -1,0 +1,16 @@
+---------- Error at tests/warn/string-interp-uninferred-class.jo:9:20 ---------------
+|   println "a\{make(undefinedVar)}b"
+|                    ^^^^^^^^^^^^
+|                    Undefined term name undefinedVar
+
+---------- Error at tests/warn/string-interp-uninferred-class.jo:9:15 ---------------
+|   println "a\{make(undefinedVar)}b"
+|               ^^^^^^^^^^^^^^^^^^
+|               Expect type StringLike, found = Box[?T]
+
+---------- Error at tests/warn/string-interp-uninferred-class.jo:9:19 ---------------
+|   println "a\{make(undefinedVar)}b"
+|                   ^
+|                   Cannot infer a type for type variable ?T
+
+3 error(s), 0 warning(s)

--- a/tests/warn/string-interp-uninferred.jo
+++ b/tests/warn/string-interp-uninferred.jo
@@ -1,0 +1,3 @@
+// String interpolation part whose type is left uninferred
+def main(): Unit =
+  println "a\{1 ~ undefinedVar}b"

--- a/tests/warn/string-interp-uninferred.jo.check
+++ b/tests/warn/string-interp-uninferred.jo.check
@@ -1,0 +1,16 @@
+---------- Error at tests/warn/string-interp-uninferred.jo:3:19 ---------------
+|   println "a\{1 ~ undefinedVar}b"
+|                   ^^^^^^^^^^^^
+|                   Undefined term name undefinedVar
+
+---------- Error at tests/warn/string-interp-uninferred.jo:3:15 ---------------
+|   println "a\{1 ~ undefinedVar}b"
+|               ^^^^^^^^^^^^^^^^
+|               Expect type StringLike, found = Int ~ ?T
+
+---------- Error at tests/warn/string-interp-uninferred.jo:3:18 ---------------
+|   println "a\{1 ~ undefinedVar}b"
+|                  ^
+|                  Cannot infer a type for type variable ?T
+
+3 error(s), 0 warning(s)

--- a/tests/warn/type-annot-error.jo
+++ b/tests/warn/type-annot-error.jo
@@ -1,0 +1,3 @@
+def main(): Unit =
+  val s: String = "x"
+  val m = Map("k" ~ (s: Int))

--- a/tests/warn/type-annot-error.jo.check
+++ b/tests/warn/type-annot-error.jo.check
@@ -1,0 +1,11 @@
+---------- Error at tests/warn/type-annot-error.jo:3:22 ---------------
+|   val m = Map("k" ~ (s: Int))
+|                      ^
+|                      Not a function: s: String
+
+---------- Error at tests/warn/type-annot-error.jo:3:14 ---------------
+|   val m = Map("k" ~ (s: Int))
+|              ^
+|              Cannot infer a type for type variable ?V
+
+2 error(s), 0 warning(s)

--- a/tests/warn/vararg-uninferred-elem-empty.jo
+++ b/tests/warn/vararg-uninferred-elem-empty.jo
@@ -1,0 +1,3 @@
+// The vararg element type is never determined
+def main(): Unit =
+  val m = Map("k" ~ [])

--- a/tests/warn/vararg-uninferred-elem-empty.jo.check
+++ b/tests/warn/vararg-uninferred-elem-empty.jo.check
@@ -1,0 +1,6 @@
+---------- Error at tests/warn/vararg-uninferred-elem-empty.jo:3:23 ---------------
+|   val m = Map("k" ~ [])
+|                       ^
+|                       Cannot infer a type for type variable ?T
+
+1 error(s), 0 warning(s)

--- a/tests/warn/vararg-uninferred-elem.jo
+++ b/tests/warn/vararg-uninferred-elem.jo
@@ -1,0 +1,5 @@
+// The vararg element type is determined only by the erroneous argument
+def collect[T](xs: ..T): Int = 0
+
+def main(): Unit =
+  println(collect(1 ~ undefinedVar))

--- a/tests/warn/vararg-uninferred-elem.jo.check
+++ b/tests/warn/vararg-uninferred-elem.jo.check
@@ -1,0 +1,11 @@
+---------- Error at tests/warn/vararg-uninferred-elem.jo:5:23 ---------------
+|   println(collect(1 ~ undefinedVar))
+|                       ^^^^^^^^^^^^
+|                       Undefined term name undefinedVar
+
+---------- Error at tests/warn/vararg-uninferred-elem.jo:5:22 ---------------
+|   println(collect(1 ~ undefinedVar))
+|                      ^
+|                      Cannot infer a type for type variable ?T
+
+2 error(s), 0 warning(s)

--- a/tests/warn/vararg-uninferred-mixed-named.jo
+++ b/tests/warn/vararg-uninferred-mixed-named.jo
@@ -1,0 +1,7 @@
+// ..Mixed[T] named argument leaves the element type uninferred
+import jo.compile.Mixed
+
+def g(xs: ..Mixed[Any]): Unit = pass
+
+def main(): Unit =
+  g(key = "k" ~ undefinedVar)

--- a/tests/warn/vararg-uninferred-mixed-named.jo.check
+++ b/tests/warn/vararg-uninferred-mixed-named.jo.check
@@ -1,0 +1,11 @@
+---------- Error at tests/warn/vararg-uninferred-mixed-named.jo:7:17 ---------------
+|   g(key = "k" ~ undefinedVar)
+|                 ^^^^^^^^^^^^
+|                 Undefined term name undefinedVar
+
+---------- Error at tests/warn/vararg-uninferred-mixed-named.jo:7:16 ---------------
+|   g(key = "k" ~ undefinedVar)
+|                ^
+|                Cannot infer a type for type variable ?T
+
+2 error(s), 0 warning(s)

--- a/tests/warn/vararg-uninferred-mixed-positional.jo
+++ b/tests/warn/vararg-uninferred-mixed-positional.jo
@@ -1,0 +1,7 @@
+// ..Mixed[T] positional argument leaves the element type uninferred
+import jo.compile.Mixed
+
+def g(xs: ..Mixed[Any]): Unit = pass
+
+def main(): Unit =
+  g("k" ~ undefinedVar)

--- a/tests/warn/vararg-uninferred-mixed-positional.jo.check
+++ b/tests/warn/vararg-uninferred-mixed-positional.jo.check
@@ -1,0 +1,11 @@
+---------- Error at tests/warn/vararg-uninferred-mixed-positional.jo:7:11 ---------------
+|   g("k" ~ undefinedVar)
+|           ^^^^^^^^^^^^
+|           Undefined term name undefinedVar
+
+---------- Error at tests/warn/vararg-uninferred-mixed-positional.jo:7:10 ---------------
+|   g("k" ~ undefinedVar)
+|          ^
+|          Cannot infer a type for type variable ?T
+
+2 error(s), 0 warning(s)

--- a/tests/warn/vararg-uninferred-mixed-splice.jo
+++ b/tests/warn/vararg-uninferred-mixed-splice.jo
@@ -1,0 +1,7 @@
+// ..Mixed[T] splice of an erroneous argument
+import jo.compile.Mixed
+
+def g(xs: ..Mixed[Any]): Unit = pass
+
+def main(): Unit =
+  g(..undefinedVar)

--- a/tests/warn/vararg-uninferred-mixed-splice.jo.check
+++ b/tests/warn/vararg-uninferred-mixed-splice.jo.check
@@ -1,0 +1,6 @@
+---------- Error at tests/warn/vararg-uninferred-mixed-splice.jo:7:7 ---------------
+|   g(..undefinedVar)
+|       ^^^^^^^^^^^^
+|       Undefined term name undefinedVar
+
+1 error(s), 0 warning(s)

--- a/tests/warn/vararg-uninferred-named.jo
+++ b/tests/warn/vararg-uninferred-named.jo
@@ -1,0 +1,7 @@
+// ..Named[T] argument leaves the element type uninferred
+import jo.compile.Named
+
+def h(xs: ..Named[Any]): Unit = pass
+
+def main(): Unit =
+  h(key = "k" ~ undefinedVar)

--- a/tests/warn/vararg-uninferred-named.jo.check
+++ b/tests/warn/vararg-uninferred-named.jo.check
@@ -1,0 +1,11 @@
+---------- Error at tests/warn/vararg-uninferred-named.jo:7:17 ---------------
+|   h(key = "k" ~ undefinedVar)
+|                 ^^^^^^^^^^^^
+|                 Undefined term name undefinedVar
+
+---------- Error at tests/warn/vararg-uninferred-named.jo:7:16 ---------------
+|   h(key = "k" ~ undefinedVar)
+|                ^
+|                Cannot infer a type for type variable ?T
+
+2 error(s), 0 warning(s)

--- a/tests/warn/vararg-uninferred-splice-empty.jo
+++ b/tests/warn/vararg-uninferred-splice-empty.jo
@@ -1,0 +1,3 @@
+// The spliced element type is never determined
+def main(): Unit =
+  val m = Map(..[])

--- a/tests/warn/vararg-uninferred-splice-empty.jo.check
+++ b/tests/warn/vararg-uninferred-splice-empty.jo.check
@@ -1,0 +1,21 @@
+---------- Error at tests/warn/vararg-uninferred-splice-empty.jo:3:20 ---------------
+|   val m = Map(..[])
+|                    ^
+|                    The auto type is not fully instantiated: Ord[?K]
+
+---------- Error at tests/warn/vararg-uninferred-splice-empty.jo:3:11 ---------------
+|   val m = Map(..[])
+|           ^^^^^^^^^
+|           The member candidate type is not fully instantiated: ?K
+
+---------- Error at tests/warn/vararg-uninferred-splice-empty.jo:3:14 ---------------
+|   val m = Map(..[])
+|              ^
+|              Cannot infer a type for type variable ?K
+
+---------- Error at tests/warn/vararg-uninferred-splice-empty.jo:3:14 ---------------
+|   val m = Map(..[])
+|              ^
+|              Cannot infer a type for type variable ?V
+
+4 error(s), 0 warning(s)

--- a/tests/warn/vararg-uninferred-splice.jo
+++ b/tests/warn/vararg-uninferred-splice.jo
@@ -1,0 +1,5 @@
+// The spliced element type is determined only by the erroneous argument
+def collect[T](xs: ..T): Int = 0
+
+def main(): Unit =
+  println(collect(..[1 ~ undefinedVar]))

--- a/tests/warn/vararg-uninferred-splice.jo.check
+++ b/tests/warn/vararg-uninferred-splice.jo.check
@@ -1,0 +1,11 @@
+---------- Error at tests/warn/vararg-uninferred-splice.jo:5:26 ---------------
+|   println(collect(..[1 ~ undefinedVar]))
+|                          ^^^^^^^^^^^^
+|                          Undefined term name undefinedVar
+
+---------- Error at tests/warn/vararg-uninferred-splice.jo:5:25 ---------------
+|   println(collect(..[1 ~ undefinedVar]))
+|                         ^
+|                         Cannot infer a type for type variable ?T
+
+2 error(s), 0 warning(s)


### PR DESCRIPTION
Harden invariants about applications

## Summary

The helper `.appliedTo` should never do adaptation nor inference: that belongs to type checking. We added assertions to enforce the rule.

We also updated incorrect usage of `.appliedTo` related to varargs: those places need adaptation or inference, which is now handled in a principled way for all such use cases.

## Checklist

- [x] Added / updated tests under `tests/pos/` or `tests/warn/`
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

No

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

