### PR TITLE
Release Jo 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.2] - 2026-09-08
+
+### Changed
+
+- The `asInt`, `asFloat`, `asString` and `asBool` shortcuts on `py.Dynamic`,
+  `rb.Dynamic` and `js.Dynamic` now check that the foreign value has exactly the
+  corresponding host type and abort with a descriptive error otherwise. In
+  particular, Python's `asInt` rejects `bool` values even though Python treats
+  `bool` as a subclass of `int`. The generic `cast[T]` remains an unchecked
+  reinterpretation for typed wrappers and other advanced uses. ([#107])
+- Refreshed the `jo-lang.org` logo and site visuals. ([#109])
+
+### Fixed
+
+- The parser no longer crashes when a reserved word such as `section`, `union`,
+  `view`, `interface` or `namespace` appears in a `val` or `for` binder
+  position; it reports a source-located diagnostic instead. ([#106])
+- The typer no longer crashes on vararg applications whose function or argument
+  types are not yet fully initialized. Adaptation and inference for varargs are
+  now handled uniformly during type checking rather than inside `.appliedTo`.
+  ([#108])
+
+### Security
+
+- Values crossing the Python, Ruby and JavaScript FFI boundaries through the
+  `as*` shortcuts are now type-checked at the boundary, so a mistyped foreign
+  value fails immediately instead of propagating into typed Jo code. ([#107])
+
+### Compatibility
+
+- Code that relied on the `as*` shortcuts silently reinterpreting a foreign
+  value of a different host type now aborts at runtime. Use `cast[T]` where an
+  unchecked reinterpretation is intended. ([#107])
+- No library recompilation is required.
+
+[#106]: https://github.com/typescope/jo/pull/106
+[#107]: https://github.com/typescope/jo/pull/107
+[#108]: https://github.com/typescope/jo/pull/108
+[#109]: https://github.com/typescope/jo/pull/109
+
 ## [0.13.1] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p>For the joy of secure programming</p>
 
   [![CI](https://github.com/typescope/jo/actions/workflows/ci.yml/badge.svg)](https://github.com/typescope/jo/actions/workflows/ci.yml)
-  [![Release](https://img.shields.io/badge/release-v0.13.1-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.13.1)
+  [![Release](https://img.shields.io/badge/release-v0.13.2-blue.svg)](https://github.com/typescope/jo/releases/tag/v0.13.2)
   [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
   [![Docs](https://img.shields.io/badge/docs-jo--lang.org-teal.svg)](https://jo-lang.org)
 </div>

--- a/docs/public/versions.jsonl
+++ b/docs/public/versions.jsonl
@@ -13,3 +13,4 @@
 {"version":"0.12.5","url":"https://github.com/typescope/jo/releases/download/v0.12.5/jo-0.12.5.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.12.5/jo-0.12.5.tar.gz.sha256","date":"2026-08-22"}
 {"version":"0.13.0","url":"https://github.com/typescope/jo/releases/download/v0.13.0/jo-0.13.0.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.13.0/jo-0.13.0.tar.gz.sha256","date":"2026-08-25"}
 {"version":"0.13.1","url":"https://github.com/typescope/jo/releases/download/v0.13.1/jo-0.13.1.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.13.1/jo-0.13.1.tar.gz.sha256","date":"2026-08-30"}
+{"version":"0.13.2","url":"https://github.com/typescope/jo/releases/download/v0.13.2/jo-0.13.2.tar.gz","sha256url":"https://github.com/typescope/jo/releases/download/v0.13.2/jo-0.13.2.tar.gz.sha256","date":"2026-09-08"}

--- a/stack-lang/tool/JoVersion.scala
+++ b/stack-lang/tool/JoVersion.scala
@@ -1,4 +1,4 @@
 package tool
 
 object JoVersion:
-  val current: Version = Version(0, 13, 1)
+  val current: Version = Version(0, 13, 2)


### PR DESCRIPTION
Release Jo 0.13.2.

## Summary

- Bump `JoVersion` to `0.13.2`
- Update the release badge in `README.md`
- Add the `0.13.2` section to `CHANGELOG.md` covering #106, #107, #108 and #109
- Append the `0.13.2` entry to `docs/public/versions.jsonl`

## Checklist

- [x] ~Added / updated tests~ — release metadata only
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off

## Verification

- `bin/jo.dev --version` prints `0.13.2`

## Security impact

No new code. The changelog records the FFI boundary type checks introduced in #107.

## Compatibility impact

No new code. The changelog records that the `as*` FFI shortcuts now abort on a
host-type mismatch (#107); no library recompilation is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPX9H8zXuNFXrMj4sUkRT2