### PR TITLE
Collect Python imports at program beginning to improve performance

### DIFF
--- a/runtime/python/Runtime.jo
+++ b/runtime/python/Runtime.jo
@@ -34,6 +34,13 @@ end
 
 private def builtins: BuiltIn = py.module("builtins").cast[BuiltIn]
 
+// Python `list * n`, which repeats the list n times in one C-level operation.
+@py.interop
+private interface ListRepeat
+  @py.targetName("__mul__")
+  def repeat(n: Int): py.List
+end
+
 //------------------------------------------------------------------------------
 //
 // Bytes operations (Bytes.Repr is Python `bytes`)
@@ -65,12 +72,13 @@ end
 
 private section RefArray
   def create[T](size: Int): Array[T] =
-    val result: py.List = builtins.list()
-    var i = 0
-    while i < size do
-      result.append(py.none)
-      i = i + 1
-    end
+    // A Python list has no unfilled slots: every index must already exist
+    // before `set` can write to it, so the None fill is not optional. `[None]
+    // * size` performs it in C, where appending one at a time costs a Python
+    // loop iteration and a method call per element.
+    val seed: py.List = builtins.list()
+    seed.append(py.none)
+    val result: py.List = py.dynamic(seed).cast[ListRepeat].repeat(size)
     py.dynamic(result).cast[Array[T]]
 
   def get[T](arr: Any, i: Int): T = py.dynamic(arr)[i].cast[T]

--- a/stack-lang/python/Printer.scala
+++ b/stack-lang/python/Printer.scala
@@ -90,6 +90,13 @@ object Printer:
     emit("# Generated Python code")
     emitBlankLine()
 
+    // Hoisted module imports
+    if program.imports.nonEmpty then
+      program.imports.foreach: imp =>
+        emitLine("import ", imp.module, " as ", imp.alias)
+
+      emitNewline()
+
     // Definitions
     program.defs.foreach: defn =>
       emitDef(defn)

--- a/stack-lang/python/PythonCodeGen.scala
+++ b/stack-lang/python/PythonCodeGen.scala
@@ -190,9 +190,15 @@ class PythonCodeGen(runtime: PythonRuntime, rewire: Map[Symbol, Symbol])(using d
     // Combine everything: global init + singleton init + start call
     val mainBlock = P.Block(globalInit ++ singletonInits :+ startCall)
 
+    // Hoisted `import <module> as <alias>` lines, one per module named by a
+    // `py.module("...")` call site reached during compilation above.
+    val imports = runtime.moduleIds.toList.map: (name, alias) =>
+      P.Import(name, alias)
+
     P.Program(
       defs = defs.toList,
-      mainCall = mainBlock
+      mainCall = mainBlock,
+      imports = imports
     )
 
   /** Compile a function definition */
@@ -769,16 +775,24 @@ class PythonCodeGen(runtime: PythonRuntime, rewire: Map[Symbol, Symbol])(using d
           compileExpr(receiver, enforcePurity)
 
         else if sym == runtime.py_module then
-          // importModule(name) → importlib.import_module(name)
+          // module(name) → a global bound by a hoisted `import name as alias`.
+          // The import runs once at module load, so the call site is a plain
+          // global read instead of an importlib round-trip (~890ns each).
           val pkg :: Nil = args: @unchecked
-          val (pkgStats, pkgExpr) = compileExpr(pkg, enforcePurity = false)
-          val importlib = P.Call(None, "__import__", List(P.StringLit("importlib")))
-          val call = P.Call(Some(importlib), "import_module", List(pkgExpr))
-          if enforcePurity then
-            val tempName = freshTemp()
-            (pkgStats :+ P.Assign(tempName, call), P.Ident(tempName))
-          else
-            (pkgStats, call)
+          pkg match
+            case Literal(Constant.String(name)) if PythonRuntime.isImportableModuleName(name) =>
+              (Nil, P.Ident(runtime.getOrCreateModuleId(name)))
+
+            case _ =>
+              // Non-literal (or non-importable) name: fall back to importlib
+              val (pkgStats, pkgExpr) = compileExpr(pkg, enforcePurity = false)
+              val importlib = P.Call(None, "__import__", List(P.StringLit("importlib")))
+              val call = P.Call(Some(importlib), "import_module", List(pkgExpr))
+              if enforcePurity then
+                val tempName = freshTemp()
+                (pkgStats :+ P.Assign(tempName, call), P.Ident(tempName))
+              else
+                (pkgStats, call)
 
         else if sym == runtime.py_call then
           // py.call(f, args...) → f(*args, **kwargs)

--- a/stack-lang/python/PythonRuntime.scala
+++ b/stack-lang/python/PythonRuntime.scala
@@ -52,6 +52,14 @@ object PythonRuntime:
   def isValidIdentifier(name: String): Boolean =
     hasIdentifierShape(name) && !keywords.contains(name)
 
+  /** Can `name` be written as the module path of an `import <name> as <alias>`?
+    *
+    * Dotted paths are allowed: `import os.path as _m` binds the submodule,
+    * exactly like `importlib.import_module("os.path")`.
+    */
+  def isImportableModuleName(name: String): Boolean =
+    name.nonEmpty && name.split("\\.", -1).forall(isValidMemberName)
+
 /** Functions to support Python platform at runtime
   *
   * Run-time symbols are only available to the compiler.
@@ -63,6 +71,10 @@ class PythonRuntime(using defn: Definitions):
   // Map from singleton object symbol to unique global variable name
   val singletonIds: mutable.Map[Symbol, String] = mutable.Map.empty
 
+  // Map from Python module name to the global alias it is imported under.
+  // Insertion-ordered so generated imports are stable across runs.
+  val moduleIds: mutable.LinkedHashMap[String, String] = mutable.LinkedHashMap.empty
+
   val runtimeNames = List("print", "sys")
 
   /** Get or create a unique global name for a context parameter */
@@ -71,6 +83,19 @@ class PythonRuntime(using defn: Definitions):
       // Generate unique global name: _param_jo_IO_stdout
       val safeName = sym.fullName.replace('.', '_')
       s"_param_$safeName"
+    })
+
+  /** Get or create the global alias a Python module is imported under.
+    *
+    * The encoding doubles `_` before turning `.` into `_`, which keeps it
+    * injective: `importlib.metadata` and `importlib_metadata` are distinct
+    * modules and must not collapse onto one alias.
+    */
+  def getOrCreateModuleId(name: String): String =
+    moduleIds.getOrElseUpdate(name, {
+      // os.path -> _pymodule_os_path, os_path -> _pymodule_os__path
+      val safeName = name.replace("_", "__").replace('.', '_')
+      s"_pymodule_$safeName"
     })
 
   /** Get or create a unique global name for a singleton object */

--- a/stack-lang/python/Trees.scala
+++ b/stack-lang/python/Trees.scala
@@ -164,10 +164,18 @@ object Trees:
     base: Option[String] = None     // Optional base class name
   ) extends Def
 
+  /** Module import: import <module> as <alias>
+    *
+    * Emitted at the top of the file, one per distinct module named by a
+    * `py.module("...")` call site, so that call sites are plain global reads.
+    */
+  case class Import(module: String, alias: String)
+
   /** Complete Python program */
   case class Program(
     defs: List[Def],               // Function and class definitions
-    mainCall: Stat                 // Entry point (initialization + start call in a Block)
+    mainCall: Stat,                // Entry point (initialization + start call in a Block)
+    imports: List[Import] = Nil    // Hoisted Python module imports
   )
 
 end Trees


### PR DESCRIPTION

## Summary

Hoisting py.module to module-level imports cuts module access from `843 ns` to `13 ns` per call site. The price to pay is to import all modules at the beginning of program.

Cost of `[1, 2, 5, 7]` in Jo, compiled to Python:

```
┌─────────┬─────────────┐
│         │ per literal │
├─────────┼─────────────┤
│ before  │ 29,741 ns   │
├─────────┼─────────────┤
│ after   │ 2,746 ns    │
├─────────┼─────────────┤
│ speedup │ 10.8×       │
└─────────┴─────────────┘
```

Only performance tweak, no interface or semantic changes.

## Checklist

- [x] ~Added / updated tests under `tests/pos/` or `tests/warn/`~
- [x] ~Docs updated if the change affects user-visible behavior~
- [x] All commits are signed off ([why?](https://github.com/typescope/jo/blob/main/CONTRIBUTING.md#contribution-terms))

<details>
<summary>How to sign off commits</summary>

Use `git commit -s` to add the `Signed-off-by` line automatically:

To add a sign-off to the last commit retroactively:

```bash
git commit --amend -s --no-edit
```

To add sign-off to the last 3 commits:

```
git rebase --signoff HEAD~3
```

</details>

## Security impact

<!-- Does this touch capability checking, FFI boundaries, or auth paths? If so, describe. -->

No

## Compatibility impact

<!-- Does this affect compatibility? If so, describe. -->

No

- [x] Source compatibility: existing code continue to compile
- [x] SAST compatibility
  - [x] forward compatibility: new libraries can be used by old compiler
  - [x] backward comopatibility: old libraries can be used by new compiler
- [x] Standard Library compatibility:
  - [x] forward compatibility: new code can work with old stdlib
  - [x] backward compatibility: old code work with the new stdlib
- [x] Runtime Library compatibility:
  - [x] forward compatibility: new code can work with old runtime
  - [x] backward compatibility: old code work with the new runtime
- [x] Build tool
  - [x] Build spec compatibility: old projects continue to build
  - [x] Joy package compatibility: old .joy can be consumed by new build tool

